### PR TITLE
修复启动器强杀恢复与状态判定

### DIFF
--- a/.github/workflows/gui-release-candidate.yml
+++ b/.github/workflows/gui-release-candidate.yml
@@ -98,6 +98,16 @@ jobs:
           python -m py_compile claude-instruct.py
           python -m pytest -q tests
 
+      # These exercise the source CLI on a Windows filesystem. The installed
+      # sidecar smoke below remains the package-level runtime evidence.
+      - name: Windows source-CLI launcher migration and forced-kill recovery tests
+        shell: pwsh
+        run: |
+          python -m pytest -q tests/test_transaction_recovery.py -k "forced_kill_after_first_legacy_launcher_move"
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          python -m pytest -q tests/test_claude_instruct.py -k "legacy_launcher"
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
       - name: Install sidecar build requirements
         shell: pwsh
         run: python -m pip install -r gui/requirements-build.txt
@@ -369,6 +379,8 @@ jobs:
             packaged_runtime_smoke = $true
             scoped_restore_smoke = $true
             recovery_smoke = $true
+            source_cli_legacy_launcher_migration_e2e = $true
+            source_cli_forced_kill_recovery_e2e = $true
             privacy_smoke = $true
             gui_process_smoke = $true
             single_instance_smoke = $true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - 所有写路径（install / uninstall / 受控 restore）由 scope 本地的排他锁（`.keysmith.lock`，O_EXCL，含 `{pid,label,acquired_at}`）与持久化事务日志（`.journal-<uuid>.json`，`claude-keysmith-journal/v1`）保护；每个 mutation 前后原子落盘 before/after 指纹。
 - 两阶段 `pending` → `committed`：commit 前中断逆序回滚到之前的状态（恢复指纹校验过的备份，或删除事务新建文件）；commit 后永不反转，只做残留核验，核验干净的 journal 被下一次写入或 `recover` 消费。
 - 修复 mutation 后指纹只更新了临时字典、没有写回实际 journal 的事务证据缺口；强杀后 recovery 现在能依据持久化 after 指纹精确判断，第三方后续修改仍会失败关闭。
+- Windows 旧 launcher 迁移在任何移动前持久化 source / backup 路径与源指纹，并在每个成功移动后落盘进度；强杀发生在首个 rename 后也能由 `recover` 精确还原。恢复使用 no-overwrite 移动，悬空同名链接、被重建目标、篡改备份或同内容但不同文件身份的竞态均失败关闭并保留证据。
 - 原子写临时文件采用 keysmith 专属命名；强杀遗留会让 status 标记 recovery-required、阻塞新写入，并由 recover 只读预览后定向清理。
 - 失败关闭：活跃他方锁、损坏 journal、原子临时残留、未知修改（指纹既不等于 before 也不等于 after）、回滚目标被重建、找不到匹配备份等情况一律阻塞并保留证据。设计见 `docs/transaction-recovery.md`。
 
@@ -27,6 +28,7 @@
 
 - 修复 macOS / Linux wrapper 将 `command -v claude` 的符号链接解析结果（版本目录）烙进 wrapper，导致 Claude 更新切换版本后失效的问题。
 - wrapper 保留已解析路径作为快路径；路径消失时每次调用重新经 `command -v claude` 解析（zsh 下以 `disable -f claude` / `enable -f claude` 包裹，附 `command -v -p` 兜底）；全部解析失败返回 127 并给出干净诊断。
+- `status` / `doctor` 对已消失的旧快路径按动态 wrapper 语义判断，不再在隔离 npm prefix 的 Claude Code 包版本目录切换成功后误报 `shell_wrapper_current:false` / `runtime_ready:false`；仍会拒绝任何其它 wrapper 结构漂移。
 
 **参数校验：**
 
@@ -43,9 +45,9 @@
 ### 发布候选构建链
 
 - `gui-release-candidate` workflow 仅用 `contents: read` 且无 secrets：main PR 自动生成 `release_eligible:false` 的验证 artifact；合并后必须在 main 上传入精确 `expected_sha` 才能生成 `release_eligible:true` 候选。Windows x64 与 macOS ARM64 先跑 CLI / 前端 / Rust 全部门禁，再原生构建 PyInstaller sidecar 与 NSIS / DMG，核验安装/卸载或挂载、版本、架构、签名状态、source commit 与哈希后上传 artifact；不打 tag、不建 Release。
-- Windows 候选在原生 runner 完成静默 currentUser 安装/卸载、冻结 sidecar runtime、PowerShell 5.1 / 7 wrapper、scoped restore、原子残留 recover、隐私、GUI 进程与单实例 smoke；安装器、GUI、sidecar 与 uninstaller 均确认 `NotSigned`。`SHA256SUMS` 强制写为 LF-only，并在上传前拒绝 CR 字节，保证 macOS/Linux 可直接 `shasum -c`。
-- `docs/beta-acceptance.md` 记录 125 / 113 / 7 本地门禁、完整 ad-hoc 签名与 `spctl` 拒绝、真实进程组强杀后的 recovery-required / 阻塞写入 / 纯只读预览 / 精确回滚链，以及 macOS GUI Dashboard / Deploy / Manage / 操作中关闭实体机验收；未取证的 Gatekeeper 用户视角、真实 Claude 升级与 Windows 实体机项目继续保持 PENDING。
-- 发布政策明确区分：无签名 / notarization / Authenticode / 自动更新是 `desktop-v0.1.0-beta.1` 已接受且必须披露的限制；真正阻塞 beta 外发的是 main 候选可追溯性与 `docs/beta-acceptance.md` 中尚未完成的实体机、用户视角和事务强杀恢复验收。
+- Windows 候选在原生 runner 完成静默 currentUser 安装/卸载、冻结 sidecar runtime、PowerShell 5.1 / 7 wrapper、scoped restore、原子残留 recover、隐私、GUI 进程与单实例 smoke；另以 source-CLI pytest 覆盖旧 launcher 迁移/冲突与首个 rename 后强杀恢复，`BUILD_INFO.json` 明确标为 source-CLI 证据。安装器、GUI、sidecar 与 uninstaller 均确认 `NotSigned`。`SHA256SUMS` 强制写为 LF-only，并在上传前拒绝 CR 字节，保证 macOS/Linux 可直接 `shasum -c`。
+- `docs/beta-acceptance.md` 记录 135 / 113 / 7 本地门禁、完整 ad-hoc 签名与 `spctl` 拒绝、真实进程组与 source-CLI 旧 launcher 首次移动后强杀的 recovery-required / 阻塞写入 / 纯只读预览 / 精确回滚链、隔离 npm prefix 的真实 Claude `2.1.231 → 2.1.232` 包版本切换 smoke，以及 macOS GUI Dashboard / Deploy / Manage / 操作中关闭实体机验收；用户安装的 Claude 升级、Gatekeeper 用户视角与 Windows 实体机项目继续保持 PENDING。
+- 发布政策明确区分：无签名 / notarization / Authenticode / 自动更新是 `desktop-v0.1.0-beta.1` 已接受且必须披露的限制；真正阻塞 beta 外发的是 main 候选可追溯性与 `docs/beta-acceptance.md` 中尚未完成的实体机和用户视角验收。
 - `docs/reference.md` 修正残留的 “v6 当前模板” 为 v7；新增 `docs/release-notes-drafts.md`（v7 与 desktop-v0.1.0-beta.1 同批次双 Release 草稿，未写发布日期）。
 
 ### Review 修复（本轮）

--- a/claude-instruct.py
+++ b/claude-instruct.py
@@ -33,7 +33,7 @@ import uuid
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 SAFE_NAME_RE = re.compile(r"^[A-Za-z0-9._-]+$")
 START_TEMPLATE = "<!-- claude-keysmith:start name={name} -->"
@@ -155,22 +155,6 @@ def atomic_write_text(path: Path, content: str) -> None:
                 tmp_path.unlink()
             except OSError:
                 pass
-
-
-def reserve_unique_backup_path(path: Path, timestamp: str, suffix: str = "") -> Path:
-    """Reserve a backup path so a later rename cannot overwrite another writer."""
-    extra = f"_{suffix}" if suffix else ""
-    base = path.with_name(f"{path.name}.bak_{timestamp}{extra}")
-    counter = 1
-    while True:
-        candidate = base if counter == 1 else base.with_name(f"{base.name}_{counter}")
-        counter += 1
-        try:
-            fd = os.open(str(candidate), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
-        except FileExistsError:
-            continue
-        os.close(fd)
-        return candidate
 
 
 def backup_file(path: Path, timestamp: Optional[str] = None, suffix: str = "") -> Path:
@@ -431,7 +415,7 @@ def inspect_legacy_launchers(home: Path) -> Dict[str, Any]:
     bin_dir = home / ".local" / "bin"
     ps1 = bin_dir / "claude.ps1"
     cmd = bin_dir / "claude.cmd"
-    existing = [path for path in (ps1, cmd) if path.exists()]
+    existing = [path for path in (ps1, cmd) if os.path.lexists(str(path))]
     if not existing:
         return {
             "detected": False,
@@ -451,9 +435,11 @@ def inspect_legacy_launchers(home: Path) -> Dict[str, Any]:
             "conflict_paths": [str(path) for path in existing],
         }
 
+    ps1_regular = ps1.is_file() and not ps1.is_symlink()
+    cmd_regular = cmd.is_file() and not cmd.is_symlink()
     ps1_lower = ps1_text.lower()
     ps1_known = bool(
-        ps1.is_file()
+        ps1_regular
         and "keysmith" in ps1_lower
         and ("system-prompt" in ps1_lower or "append-prompt" in ps1_lower)
     )
@@ -463,7 +449,7 @@ def inspect_legacy_launchers(home: Path) -> Dict[str, Any]:
         cmd_lines = cmd_lines[1:]
     forwarder = cmd_lines[0] if cmd_lines else ""
     cmd_known = bool(
-        cmd.is_file()
+        cmd_regular
         and len(cmd_lines) in (1, 2)
         and LEGACY_CMD_FORWARD_RE.fullmatch(forwarder)
         and (
@@ -481,47 +467,143 @@ def inspect_legacy_launchers(home: Path) -> Dict[str, Any]:
     }
 
 
-def migrate_legacy_launchers(home: Path, timestamp: str) -> List[Tuple[Path, Path]]:
-    """Rename a recognized launcher pair to unique recovery backups."""
+def _unique_backup_candidate(path: Path, timestamp: str, suffix: str = "") -> Path:
+    """Choose an unused backup name without touching the filesystem."""
+    extra = f"_{suffix}" if suffix else ""
+    base = path.with_name(f"{path.name}.bak_{timestamp}{extra}")
+    counter = 1
+    while True:
+        candidate = base if counter == 1 else base.with_name(f"{base.name}_{counter}")
+        if not os.path.lexists(str(candidate)):
+            return candidate
+        counter += 1
+
+
+def plan_legacy_launcher_migration(home: Path, timestamp: str) -> List[Dict[str, Any]]:
+    """Build a side-effect-free launcher migration plan with source fingerprints."""
     inspection = inspect_legacy_launchers(home)
     if inspection["conflict"]:
         raise ValueError("检测到未知 ~/.local/bin/claude.ps1 或 claude.cmd，拒绝覆盖")
     if not inspection["detected"]:
         return []
 
+    plan: List[Dict[str, Any]] = []
+    for raw_path in inspection["paths"]:
+        source = Path(raw_path)
+        before = file_evidence(source)
+        if not before.get("exists") or source.is_symlink():
+            raise ValueError(f"旧 launcher 在迁移规划期间发生变化，拒绝继续: {source}")
+        plan.append(
+            {
+                "source": str(source),
+                "backup": str(_unique_backup_candidate(source, timestamp, "pre_v6")),
+                "before": before,
+            }
+        )
+    verification = inspect_legacy_launchers(home)
+    if not verification["detected"] or verification["paths"] != inspection["paths"]:
+        raise ValueError("旧 launcher 在迁移规划期间发生变化，拒绝继续")
+    if any(
+        not _migration_item_matches(Path(item["source"]), item["before"])
+        for item in plan
+    ):
+        raise ValueError("旧 launcher 在迁移规划期间发生变化，拒绝继续")
+    return plan
+
+
+def _move_file_no_overwrite(source: Path, target: Path) -> None:
+    """Move a regular file without ever replacing an existing target."""
+    if os.name == "nt":
+        os.rename(str(source), str(target))
+        return
+
+    # POSIX rename replaces an existing destination. A same-directory hard
+    # link plus unlink preserves no-overwrite semantics and is crash-recoverable.
+    os.link(str(source), str(target))
+    try:
+        source.unlink()
+    except BaseException:
+        try:
+            target.unlink()
+        except OSError:
+            pass
+        raise
+
+
+def _migration_item_matches(path: Path, expected: Dict[str, Any]) -> bool:
+    try:
+        return bool(
+            os.path.lexists(str(path))
+            and path.is_file()
+            and not path.is_symlink()
+            and file_evidence(path).get("sha256") == expected.get("sha256")
+        )
+    except OSError:
+        return False
+
+
+def _same_posix_file_identity(first: Path, second: Path) -> bool:
+    if os.name == "nt":
+        return False
+    try:
+        return os.path.samestat(first.stat(), second.stat())
+    except OSError:
+        return False
+
+
+def migrate_legacy_launchers(
+    home: Path,
+    timestamp: str,
+    *,
+    migration_plan: Optional[List[Dict[str, Any]]] = None,
+    on_moved: Optional[Callable[[Path, Path], None]] = None,
+) -> List[Tuple[Path, Path]]:
+    """Rename a recognized launcher pair to unique recovery backups."""
+    plan = migration_plan if migration_plan is not None else plan_legacy_launcher_migration(home, timestamp)
+    if not plan:
+        return []
+
     moved: List[Tuple[Path, Path]] = []
     try:
-        for raw_path in inspection["paths"]:
-            source = Path(raw_path)
-            backup = reserve_unique_backup_path(source, timestamp, "pre_v6")
-            try:
-                os.replace(str(source), str(backup))
-            except BaseException:
-                try:
-                    backup.unlink()
-                except OSError:
-                    pass
-                raise
+        for item in plan:
+            source = Path(item["source"])
+            backup = Path(item["backup"])
+            before = item.get("before") or {}
+            if not _migration_item_matches(source, before):
+                raise OSError(f"旧 launcher 在迁移前发生变化，拒绝移动: {source}")
+            if os.path.lexists(str(backup)):
+                raise FileExistsError(f"旧 launcher 备份路径已被占用，拒绝覆盖: {backup}")
+            _move_file_no_overwrite(source, backup)
             moved.append((source, backup))
+            if not _migration_item_matches(backup, before):
+                raise OSError(f"旧 launcher 在迁移期间发生变化，拒绝提交: {source}")
+            if on_moved is not None:
+                on_moved(source, backup)
     except BaseException as migration_error:
         rollback_errors: List[str] = []
+        plan_by_source = {item["source"]: item for item in plan}
         for source, backup in reversed(moved):
-            if not backup.exists():
+            before = plan_by_source[str(source)].get("before") or {}
+            source_matches = _migration_item_matches(source, before)
+            backup_matches = _migration_item_matches(backup, before)
+            if source_matches and not os.path.lexists(str(backup)):
                 continue
-            try:
-                fd = os.open(str(source), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
-                os.close(fd)
-            except OSError as exc:
-                rollback_errors.append(f"{source}: {exc}")
+            if source_matches and backup_matches:
+                if _same_posix_file_identity(source, backup):
+                    try:
+                        backup.unlink()
+                    except OSError as exc:
+                        rollback_errors.append(f"{backup}: {exc}")
+                else:
+                    rollback_errors.append(f"{source}: rollback target was recreated")
                 continue
-            try:
-                os.replace(str(backup), str(source))
-            except OSError as exc:
+            if not os.path.lexists(str(source)) and backup_matches:
                 try:
-                    source.unlink()
-                except OSError:
-                    pass
-                rollback_errors.append(f"{source}: {exc}")
+                    _move_file_no_overwrite(backup, source)
+                except OSError as exc:
+                    rollback_errors.append(f"{source}: {exc}")
+                continue
+            rollback_errors.append(f"{source}: launcher/backup state no longer matches the migration plan")
         if rollback_errors:
             details = "; ".join(rollback_errors)
             raise OSError(f"旧 launcher 迁移失败且回滚不完整: {details}") from migration_error
@@ -823,9 +905,43 @@ def shell_block_pattern() -> re.Pattern:
     return re.compile(rf"(?ms)^{begin}\n.*?^{end}\n?")
 
 
-def shell_wrapper_is_current(content: str, expected_block: str) -> bool:
+def _is_missing_literal_zsh_fast_path(raw: str) -> bool:
+    """Accept only a missing absolute path with no zsh expansion semantics."""
+    if not os.path.isabs(raw):
+        return False
+    if any(char in raw for char in ("$", "`", "\\")):
+        return False
+    if any(ord(char) < 0x20 or ord(char) == 0x7F for char in raw):
+        return False
+    try:
+        os.lstat(raw)
+    except FileNotFoundError:
+        return True
+    except OSError:
+        return False
+    return False
+
+
+def shell_wrapper_is_current(content: str, expected_block: str, shell_kind: str = "") -> bool:
     match = shell_block_pattern().search(content)
-    return bool(match and match.group(0) == expected_block)
+    if not match:
+        return False
+    actual_block = match.group(0)
+    if actual_block == expected_block:
+        return True
+    if shell_kind != "zsh":
+        return False
+
+    entry_pattern = re.compile(r'(?m)^  entry="([^"\n]+)"$')
+    actual_entry = entry_pattern.search(actual_block)
+    expected_entry = entry_pattern.search(expected_block)
+    if not actual_entry or not expected_entry:
+        return False
+    if not _is_missing_literal_zsh_fast_path(actual_entry.group(1)):
+        return False
+    return entry_pattern.sub('  entry="<dynamic>"', actual_block, count=1) == entry_pattern.sub(
+        '  entry="<dynamic>"', expected_block, count=1
+    )
 
 
 def ensure_shell_wrapper(content: str, block: str) -> Tuple[str, bool]:
@@ -1214,10 +1330,29 @@ def tx_remove_step(journal: TransactionJournal, path: Path) -> None:
 
 
 def tx_migrate_legacy_launchers(journal: TransactionJournal, home: Path, timestamp: str) -> List[Tuple[Path, Path]]:
-    moved = migrate_legacy_launchers(home, timestamp)
-    if not moved:
+    migration_plan = plan_legacy_launcher_migration(home, timestamp)
+    if not migration_plan:
         return []
-    step = journal_step_before(journal, "migrate", home / ".local" / "bin", moved=[[str(s), str(b)] for s, b in moved])
+
+    migration_items = [dict(item) for item in migration_plan]
+    step = journal_step_before(
+        journal,
+        "migrate",
+        home / ".local" / "bin",
+        moved=[],
+        migration_items=migration_items,
+    )
+
+    def record_moved(source: Path, backup: Path) -> None:
+        step["moved"].append([str(source), str(backup)])
+        journal._persist()
+
+    moved = migrate_legacy_launchers(
+        home,
+        timestamp,
+        migration_plan=migration_plan,
+        on_moved=record_moved,
+    )
     journal_step_after(journal, step)
     return moved
 
@@ -1393,6 +1528,97 @@ def _pending_rollback_core(
     for step in reversed(steps):
         action = step.get("action")
         if action == "migrate":
+            migration_items = step.get("migration_items")
+            if isinstance(migration_items, list):
+                for item in reversed(migration_items):
+                    if not isinstance(item, dict):
+                        blocker("迁移事务证据格式无效，拒绝回滚")
+                        continue
+                    source = Path(item.get("source", ""))
+                    backup = Path(item.get("backup", ""))
+                    before = item.get("before") or {}
+                    expected_sha = before.get("sha256")
+                    if not source.name or not backup.name or expected_sha is None:
+                        blocker(f"迁移事务缺少路径或源指纹，拒绝回滚: {source}")
+                        continue
+
+                    source_present = current_present(source)
+                    backup_present = current_present(backup)
+                    if source_present is None or backup_present is None:
+                        continue
+
+                    if source_present:
+                        try:
+                            source_regular = source.is_file() and not source.is_symlink()
+                        except OSError as exc:
+                            blocker(f"无法检查迁移回滚目标类型 {source}: {exc}")
+                            continue
+                        if not source_regular or not matches_state(source, before):
+                            blocker(f"迁移源被未知方修改或替换，拒绝回滚: {source}")
+                            continue
+                        if not backup_present:
+                            continue  # move never happened, or was already rolled back
+                        try:
+                            backup_regular = backup.is_file() and not backup.is_symlink()
+                        except OSError as exc:
+                            blocker(f"无法检查迁移备份类型 {backup}: {exc}")
+                            continue
+                        if not backup_regular or not matches_state(backup, before):
+                            blocker(f"迁移备份状态异常，拒绝清理: {backup}")
+                            continue
+                        if not _same_posix_file_identity(source, backup):
+                            blocker(f"迁移源与备份同时存在且身份不同，拒绝清理: {backup}")
+                            continue
+                        if execute:
+                            try:
+                                backup.unlink()
+                            except OSError as exc:
+                                blocker(f"无法清理已回滚的迁移备份 {backup}: {exc}")
+                                continue
+                        remember_state(
+                            backup,
+                            {"sha256": None, "size_bytes": None, "exists": False},
+                            present=False,
+                        )
+                        report("cleanup", backup, "removed duplicate backup from interrupted migration")
+                        continue
+
+                    if not backup_present:
+                        blocker(f"迁移源与备份均缺失，无法回滚: {source}")
+                        continue
+                    try:
+                        backup_regular = backup.is_file() and not backup.is_symlink()
+                    except OSError as exc:
+                        blocker(f"无法检查迁移备份类型 {backup}: {exc}")
+                        continue
+                    if not backup_regular or not matches_state(backup, before):
+                        blocker(f"迁移备份指纹不匹配，拒绝回滚: {backup}")
+                        continue
+                    try:
+                        backup_raw = read_current_bytes(backup)
+                    except OSError as exc:
+                        blocker(f"无法读取迁移备份 {backup}: {exc}")
+                        continue
+                    if hashlib.sha256(backup_raw).hexdigest() != expected_sha:
+                        blocker(f"迁移备份在恢复检查期间发生变化，拒绝使用: {backup}")
+                        continue
+                    if execute:
+                        try:
+                            _move_file_no_overwrite(backup, source)
+                        except OSError as exc:
+                            blocker(f"迁移回滚失败 {source}: {exc}")
+                            continue
+                    remember_state(source, before, present=True, raw=backup_raw)
+                    remember_state(
+                        backup,
+                        {"sha256": None, "size_bytes": None, "exists": False},
+                        present=False,
+                    )
+                    report("restore-moved", source, f"restored from {backup.name}")
+                continue
+
+            # Compatibility path for journals created before migration intent
+            # and source fingerprints were persisted.
             for source_str, backup_str in reversed(step.get("moved", [])):
                 source = Path(source_str)
                 backup = Path(backup_str)
@@ -1400,6 +1626,23 @@ def _pending_rollback_core(
                 if source_present is None:
                     continue
                 if source_present:
+                    backup_present = current_present(backup)
+                    if backup_present is None:
+                        continue
+                    if backup_present and _same_posix_file_identity(source, backup):
+                        if execute:
+                            try:
+                                backup.unlink()
+                            except OSError as exc:
+                                blocker(f"无法清理旧格式迁移恢复残留 {backup}: {exc}")
+                                continue
+                        remember_state(
+                            backup,
+                            {"sha256": None, "size_bytes": None, "exists": False},
+                            present=False,
+                        )
+                        report("cleanup", backup, "removed duplicate backup from interrupted legacy-journal recovery")
+                        continue
                     blocker(f"回滚目标已存在，拒绝覆盖: {source}")
                     continue
                 backup_present = current_present(backup)
@@ -1415,7 +1658,7 @@ def _pending_rollback_core(
                     backup_raw = None
                 if execute:
                     try:
-                        os.replace(str(backup), str(source))
+                        _move_file_no_overwrite(backup, source)
                     except OSError as exc:
                         blocker(f"迁移回滚失败 {source}: {exc}")
                         continue
@@ -1489,9 +1732,28 @@ def finish_committed_journal(record: Dict[str, Any]) -> Tuple[List[Dict[str, Any
     for step in record.get("steps", []):
         if step.get("action") != "migrate":
             continue
+        migration_items = step.get("migration_items")
+        if isinstance(migration_items, list):
+            for item in migration_items:
+                if not isinstance(item, dict):
+                    blockers.append("已提交事务的迁移证据格式无效，保留并报告")
+                    continue
+                source_raw = item.get("source")
+                backup_raw = item.get("backup")
+                before = item.get("before") or {}
+                if not source_raw or not backup_raw or before.get("sha256") is None:
+                    blockers.append("已提交事务的迁移证据不完整，保留并报告")
+                    continue
+                source = Path(source_raw)
+                backup = Path(backup_raw)
+                if os.path.lexists(str(source)):
+                    blockers.append(f"已提交事务的迁移目标被重建，保留并报告: {source}")
+                if not _migration_item_matches(backup, before):
+                    blockers.append(f"已提交事务的迁移备份指纹异常，保留并报告: {backup}")
+            continue
         for source_str, _backup_str in step.get("moved", []):
             source = Path(source_str)
-            if source.exists():
+            if os.path.lexists(str(source)):
                 blockers.append(f"已提交事务的迁移目标被重建，保留并报告: {source}")
     if not blockers:
         actions.append({"action": "cleanup", "path": record.get("scope_root", ""), "detail": "committed transaction verified; no residual cleanup required"})
@@ -2207,7 +2469,7 @@ def collect_runtime_status(paths: ScopePaths, md_filename: str, planned: Optiona
             rt["shell_kind"],
             rt["upstream_candidates"],
         )
-        wrapper_current = shell_wrapper_is_current(shell_rc_content, expected_wrapper)
+        wrapper_current = shell_wrapper_is_current(shell_rc_content, expected_wrapper, rt["shell_kind"])
     settings_aligned = bool(system_body) and settings.get("systemPrompt") == system_body
     runtime_ready = bool(
         system_complete
@@ -3014,7 +3276,7 @@ def command_runtime_doctor(args) -> int:
             rt["shell_kind"],
             rt["upstream_candidates"],
         )
-        wrapper_current = shell_wrapper_is_current(shell_rc_content, expected_wrapper)
+        wrapper_current = shell_wrapper_is_current(shell_rc_content, expected_wrapper, rt["shell_kind"])
         repair_actions: List[str] = []
         if not rt["upstream_exists"]:
             repair_actions.append("Repair or reinstall Claude Code, then rerun doctor.")
@@ -3023,7 +3285,7 @@ def command_runtime_doctor(args) -> int:
         if rt["legacy_launcher_conflict"]:
             repair_actions.append("Inspect the unknown ~/.local/bin launcher files; keysmith will not overwrite them.")
         if not wrapper_current:
-            repair_actions.append("Run install --scope user --runtime --yes to install the current PowerShell wrapper.")
+            repair_actions.append("Run install --scope user --runtime --yes to install the current shell wrapper.")
         if not rt["system_prompt"].is_file() or not rt["append_prompt"].is_file():
             repair_actions.append("Run install --scope user --runtime --yes to restore keysmith prompt files.")
         if not (system_body and settings.get("systemPrompt") == system_body):

--- a/docs/beta-acceptance.md
+++ b/docs/beta-acceptance.md
@@ -43,7 +43,7 @@
 | 超时杀整棵进程树 | `cargo test timeout_terminates_descendant_processes`：真实 `/bin/sh` 派生 `sleep 60` 后代，100ms 超时后验证后代 PID 被杀 | 通过 |
 | 2 MiB 输出失败关闭 | `cargo test oversized_output_fails_closed`：真实 `dd` 输出 3 MiB，`cli_run` 返回明确错误（"CLI 输出不完整，已阻止继续操作"），不解析半截输出；前端 parser 对未闭合 JSON 返回"输出不完整"（vitest 覆盖） | 通过 |
 | pending journal 恢复链 | `test_recover_rolls_back_pending_journal_preview_then_execute`：构造含真实 before/after 指纹的 pending journal；后续写入被阻塞，preview 报告计划且不修改目标，execute 回滚并消费 journal，重复 recover 幂等 | 通过（事务 fixture；不等同于真实进程强杀） |
-| 旧 launcher 首个移动后强杀 | source CLI 事务测试：子进程执行 runtime install，在首个 `claude.ps1` no-overwrite move 完成、after-move 进度尚未落盘时由父进程强杀；pending journal 阻塞新写入，preview 前后快照一致且计划 `restore-moved`，execute 精确还原 `.ps1/.cmd` 与此前所有 runtime 写入并清理 journal/lock/备份 | macOS 本地通过；`test_forced_kill_after_first_legacy_launcher_move_recovers_exactly`。候选 workflow 已将同一测试设为 Windows source-CLI 门禁，待本 PR Windows CI 取证；不等同于已安装冻结 sidecar 或实体机 UI 验收 |
+| 旧 launcher 首个移动后强杀 | source CLI 事务测试：子进程执行 runtime install，在首个 `claude.ps1` no-overwrite move 完成、after-move 进度尚未落盘时由父进程强杀；pending journal 阻塞新写入，preview 前后快照一致且计划 `restore-moved`，execute 精确还原 `.ps1/.cmd` 与此前所有 runtime 写入并清理 journal/lock/备份 | macOS 本地通过；`test_forced_kill_after_first_legacy_launcher_move_recovers_exactly`。Windows source-CLI 候选门禁已在 CI run `31810727817` 通过；不等同于已安装冻结 sidecar 或实体机 UI 验收 |
 | journal after 证据持久化 | `test_transaction_helpers_persist_after_evidence_and_reject_later_edit`：生产事务 helper 把 mutation 后指纹写回实际 journal；随后第三方修改会被识别为未知修改并失败关闭 | 通过 |
 | recover 预览纯只读 | `snapshot_tree` 对整个隔离 HOME 比较文件内容、mode 与 mtime；可恢复、多步同路径与 marker 场景 preview 前后快照一致 | 通过 |
 | 同路径多步逆序恢复 | `test_recover_repeated_writes_use_virtual_reverse_state`：同一路径 `A → B → C` 的 preview 与 execute 均按 `C → B → A` 判定，最终恢复原内容 | 通过 |

--- a/docs/beta-acceptance.md
+++ b/docs/beta-acceptance.md
@@ -3,7 +3,7 @@
 
 本文区分"已实际取得证据"、"发布前必须补齐的验证"与"本次未签名 beta 已接受的限制"。**本分支不发布任何产物**；外发 `desktop-v0.1.0-beta.1` 前必须完成第二节全部未完成条目。代码签名、公证、Authenticode 与自动更新不属于这次明确标记为未签名 beta 的阻塞项，但必须在产物与发布说明中如实披露。
 
-验证环境（发布候选轮，分支 `prep/gui-release-candidate`，base `bbd8ca15`）：macOS 26.5.2 / Apple Silicon（arm64）实体机；Python 3.14.6 独立 venv（`gui/requirements-build.txt` + pytest）；Node 25.9.0 / npm 11.12.1（`npm ci`）；rustc 1.93.1。所有 CLI 验证在隔离 `HOME` / `CLAUDE_KEYSMITH_HOME` / `CLAUDE_KEYSMITH_SHELL_RC` 与 fake Claude 上游下进行，未触碰真实 `~/.claude` 或真实 shell profile。
+验证环境（发布阻塞修复轮，分支 `fix/desktop-gui-p0-recovery`，base `f8b8234f`）：macOS 26.5.2 / Apple Silicon（arm64）实体机；Python 3.14.6 独立 venv（pytest 9.1.1）；Node 25.9.0 / npm 11.12.1（`npm ci`）；rustc 1.93.1。所有 CLI 验证在隔离 `HOME` / `CLAUDE_KEYSMITH_HOME` / `CLAUDE_KEYSMITH_SHELL_RC` 下进行，未触碰真实 `~/.claude` 或真实 shell profile；真实 Claude 版本切换专项仅运行临时 npm prefix 中的 `claude --version`。
 
 ## 一、发布候选轮已取得证据的验证
 
@@ -12,7 +12,7 @@
 | 项目 | 命令 / 方式 | 结果 |
 |---|---|---|
 | CLI 语法 | `python3 -m py_compile claude-instruct.py` | 通过 |
-| CLI 测试套件 | 隔离 `HOME` / `CLAUDE_KEYSMITH_HOME` 下 `python3 -m pytest -q tests` | **125 passed** |
+| CLI 测试套件 | 隔离 `HOME` / `CLAUDE_KEYSMITH_HOME` 下 `python3 -m pytest -q tests` | **135 passed** |
 | 前端测试 | `cd gui && npm test`（vitest） | **11 文件 113 passed** |
 | Rust 门禁 | `cargo fmt --check && cargo check --locked && cargo test --locked` | **7 passed**（干净检出，无需 sidecar） |
 | 前端生产构建 | `npm run build` | 通过，最大 chunk 200.18 kB，无 >500 kB 警告 |
@@ -43,11 +43,12 @@
 | 超时杀整棵进程树 | `cargo test timeout_terminates_descendant_processes`：真实 `/bin/sh` 派生 `sleep 60` 后代，100ms 超时后验证后代 PID 被杀 | 通过 |
 | 2 MiB 输出失败关闭 | `cargo test oversized_output_fails_closed`：真实 `dd` 输出 3 MiB，`cli_run` 返回明确错误（"CLI 输出不完整，已阻止继续操作"），不解析半截输出；前端 parser 对未闭合 JSON 返回"输出不完整"（vitest 覆盖） | 通过 |
 | pending journal 恢复链 | `test_recover_rolls_back_pending_journal_preview_then_execute`：构造含真实 before/after 指纹的 pending journal；后续写入被阻塞，preview 报告计划且不修改目标，execute 回滚并消费 journal，重复 recover 幂等 | 通过（事务 fixture；不等同于真实进程强杀） |
+| 旧 launcher 首个移动后强杀 | source CLI 事务测试：子进程执行 runtime install，在首个 `claude.ps1` no-overwrite move 完成、after-move 进度尚未落盘时由父进程强杀；pending journal 阻塞新写入，preview 前后快照一致且计划 `restore-moved`，execute 精确还原 `.ps1/.cmd` 与此前所有 runtime 写入并清理 journal/lock/备份 | macOS 本地通过；`test_forced_kill_after_first_legacy_launcher_move_recovers_exactly`。候选 workflow 已将同一测试设为 Windows source-CLI 门禁，待本 PR Windows CI 取证；不等同于已安装冻结 sidecar 或实体机 UI 验收 |
 | journal after 证据持久化 | `test_transaction_helpers_persist_after_evidence_and_reject_later_edit`：生产事务 helper 把 mutation 后指纹写回实际 journal；随后第三方修改会被识别为未知修改并失败关闭 | 通过 |
 | recover 预览纯只读 | `snapshot_tree` 对整个隔离 HOME 比较文件内容、mode 与 mtime；可恢复、多步同路径与 marker 场景 preview 前后快照一致 | 通过 |
 | 同路径多步逆序恢复 | `test_recover_repeated_writes_use_virtual_reverse_state`：同一路径 `A → B → C` 的 preview 与 execute 均按 `C → B → A` 判定，最终恢复原内容 | 通过 |
 | 写入故障自动回滚 | `test_install_failure_rolls_back_and_recovers_clean`：在 mutation 中注入 `OSError`，验证原内容恢复、journal/lock 清理、备份保留 | 通过（故障注入；不等同于 `SIGKILL`） |
-| committed journal 不反撤 | `test_committed_journal_is_never_reversed` / `test_crash_after_commit_window_is_consumed_by_next_write`：committed 结果保持，残留 journal 只被消费 | 通过 |
+| committed journal 不反撤 | `test_committed_journal_is_never_reversed` / `test_committed_launcher_migration_is_never_reversed` / `test_crash_after_commit_window_is_consumed_by_next_write`：committed 文件写入和 launcher 迁移结果保持，残留 journal 只被消费 | 通过 |
 | 活锁拒绝与 stale lock 回收 | 存活进程持有 `.keysmith.lock` 时写入失败关闭；死 PID stale lock 可由下一次受控操作回收 | 通过 |
 | 原子临时残留失败关闭 | 强杀可能遗留的 `.<target>.keysmith-tmp-*.tmp` 会让 status 标记 recovery-required、阻塞后续写入；recover preview 只读列出计划，execute 只清理专属临时残留，不碰其它文件 | 通过 |
 | 全局写租约边界 | vitest：execute 走独占租约、并发写拒绝、preview/读操作走共享租约不被误锁、后端同步抛错时租约释放（`api.test.js` / `store.test.js`，113 passed 内） | 通过 |
@@ -65,12 +66,18 @@
 | 操作中关闭 | restore execute 进行中点击关闭，窗口等待操作结束后退出；恢复成功且无 sidecar / lock / journal 残留 | 通过 |
 | doctor / backups 不泄漏 | `doctor --json` 键集合固定 9 键；断言输出不含 token / cookie / Bearer / sk- / base_url / ANTHROPIC 字样；`backups --json` 仅含路径、绝对 `target_path` 与指纹元数据，无文件内容 | 通过 |
 
+### Claude Code 包版本目录切换 smoke（隔离 npm prefix）
+
+- 临时安装真实 `@anthropic-ai/claude-code@2.1.231` 与 `2.1.232`，wrapper 首次运行返回 `2.1.231`；移走整个旧版本 prefix 后，不改 wrapper 即动态解析到新 prefix 并返回 `2.1.232`。
+- 修复并验证 `status --runtime --json`：旧快路径已消失且 wrapper 其它结构完整时，`shell_wrapper_current=true`、`upstream_exists=true`、`runtime_ready=true`、`upgrade_required=false`。真实 `/Users/ethan/.local/bin/claude` 保持 `2.1.212`，未被调用或修改。
+- 证据目录：`/tmp/ks-claude-switch.c6tIaH`；仅执行 `claude --version`，无登录、凭证或模型请求。
+
 ## 二、发布前仍须补齐的验证（未完成不得外发）
 
 ### macOS ARM64 实体机
 
 - [ ] 从干净（或新建隔离）账户打开未签名 `.app` / `.dmg`，确认 Gatekeeper 提示文案可接受并写入发布说明（当前 `spctl` 拒绝状态见上文，需人工记录用户视角文案）。
-- [ ] 真实 Claude Code 升级（版本目录切换）后 wrapper 仍可用（需真实 Claude 安装，隔离环境无法覆盖）。
+- [ ] 用户安装的真实 Claude Code 升级（版本目录切换）后 wrapper 仍可用；上方仅有隔离 npm prefix 的真实包版本切换 smoke，不能替代此项。
 
 ### Windows x64 原生环境
 
@@ -81,10 +88,10 @@
 - [x] GUI 进程启动并保持存活，第二实例由 single-instance guard 退出；此项只证明进程链，不代表页面视觉与交互验收。
 - [x] Windows Rust 原生测试覆盖 `taskkill /T /F` 杀父子进程树与 2 MiB 输出超限失败关闭。
 - [ ] Windows 实体机可见 UI：安装 → Dashboard/sidecar 探测 → Deploy → Manage uninstall/restore/recover → 操作中关闭。
-- [ ] 旧 launcher 迁移与同名冲突路径（`~/.local/bin/claude.ps1` / `claude.cmd`）。
+- [ ] Windows 实体机旧 launcher 迁移与同名冲突路径（`~/.local/bin/claude.ps1` / `claude.cmd`）；托管 runner 仅将 source-CLI 迁移/冲突测试设为自动门禁。
 - [ ] WebView2 bootstrapper 在无 WebView2 机器上静默安装。
 - [ ] 未签名 SmartScreen 提示文案确认并写入发布说明。
-- [ ] Windows 事务中途强杀后的 pending journal 阻塞、只读 preview 与精确恢复 E2E；当前 CI 只覆盖 Rust 超时杀树和受控原子残留恢复。
+- [ ] Windows 实体机事务中途强杀后的 pending journal 阻塞、只读 preview 与精确恢复 E2E；托管 runner 另有 source-CLI 首次 launcher 移动后强杀测试，不等同于已安装冻结 sidecar 或可见 UI 验收。
 
 ## 三、发布政策与边界声明
 

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -8,7 +8,7 @@
 | 平台 | 产物 | 配置 | 状态 |
 |---|---|---|---|
 | macOS Apple Silicon（`aarch64-apple-darwin`） | `.app` + `.dmg` | `tauri.macos.conf.json`（targets）+ `tauri.bundle.conf.json`（`externalBin`） | 核心 GUI / 强杀恢复验收通过；Gatekeeper 用户视角提示仍待记录，见 [`beta-acceptance.md`](beta-acceptance.md) |
-| Windows x64（`x86_64-pc-windows-msvc`） | NSIS currentUser 安装器，WebView2 `downloadBootstrapper`（silent） | `tauri.windows.conf.json`（`allowDowngrades: false`）+ `tauri.bundle.conf.json`（`externalBin`） | 原生 CI 构建、静默安装/卸载、冻结 sidecar、restore/recover、隐私、GUI 进程与单实例 smoke 通过；实体机可见 UI、SmartScreen、无 WebView2 与事务强杀恢复仍待验收 |
+| Windows x64（`x86_64-pc-windows-msvc`） | NSIS currentUser 安装器，WebView2 `downloadBootstrapper`（silent） | `tauri.windows.conf.json`（`allowDowngrades: false`）+ `tauri.bundle.conf.json`（`externalBin`） | 原生 CI 构建、静默安装/卸载、冻结 sidecar、restore/recover、隐私、GUI 进程与单实例 smoke 通过；另有 source-CLI launcher 迁移/强杀恢复门禁。实体机可见 UI、SmartScreen、无 WebView2 与强杀恢复仍待验收 |
 | Linux | 无 GUI 产物 | 无 | 不支持（CLI 继续支持） |
 
 两种受支持平台都只用 `cd gui && npm run bundle` 生成发行产物。该入口先原生构建 sidecar，再加载打包 overlay 启用 bundle 和 `externalBin`；裸 Tauri 构建不是发行打包入口。
@@ -18,7 +18,7 @@
 以下事项直接决定未签名 beta 能否外发，不得在取得证据前表述为已完成：
 
 1. **macOS beta 验收**：GUI Dashboard、Deploy、Manage、操作中关闭与真实进程强杀恢复 E2E 已完成；仍需记录带 quarantine 的 Gatekeeper 用户视角提示及人工安装步骤。
-2. **Windows 原生验收**：GitHub 托管 runner 已通过 sidecar/NSIS 构建、静默 install/uninstall、PowerShell wrapper、restore/recover、隐私、GUI 进程、单实例、超时杀树与输出超限；仍需 Windows 实体机完成可见 UI、操作中关闭、旧 launcher、事务强杀恢复、无 WebView2 与 SmartScreen 提示。
+2. **Windows 原生验收**：GitHub 托管 runner 已通过 sidecar/NSIS 构建、静默 install/uninstall、PowerShell wrapper、restore/recover、隐私、GUI 进程、单实例、超时杀树与输出超限，并将旧 launcher 迁移/首次移动后强杀恢复作为 source-CLI 门禁；仍需 Windows 实体机完成可见 UI、操作中关闭、旧 launcher、事务强杀恢复、无 WebView2 与 SmartScreen 提示。
 3. **候选可追溯性**：PR 验证 artifact 固定为 `release_eligible:false`；合并后必须从精确 main SHA 重新生成两端 `release_eligible:true` 候选，并复核安装器、sidecar、`BUILD_INFO.json`、LF-only `SHA256SUMS`、版本、source commit、目标架构及签名状态。
 4. **发布授权**：本轮可以完成分支、PR、合并与候选 artifact；创建 tag / GitHub Release 前必须停下取得明确授权。
 

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -8,7 +8,7 @@
 | 平台 | 产物 | 配置 | 状态 |
 |---|---|---|---|
 | macOS Apple Silicon（`aarch64-apple-darwin`） | `.app` + `.dmg` | `tauri.macos.conf.json`（targets）+ `tauri.bundle.conf.json`（`externalBin`） | 核心 GUI / 强杀恢复验收通过；Gatekeeper 用户视角提示仍待记录，见 [`beta-acceptance.md`](beta-acceptance.md) |
-| Windows x64（`x86_64-pc-windows-msvc`） | NSIS currentUser 安装器，WebView2 `downloadBootstrapper`（silent） | `tauri.windows.conf.json`（`allowDowngrades: false`）+ `tauri.bundle.conf.json`（`externalBin`） | 原生 CI 构建、静默安装/卸载、冻结 sidecar、restore/recover、隐私、GUI 进程与单实例 smoke 通过；另有 source-CLI launcher 迁移/强杀恢复门禁。实体机可见 UI、SmartScreen、无 WebView2 与强杀恢复仍待验收 |
+| Windows x64（`x86_64-pc-windows-msvc`） | NSIS currentUser 安装器，WebView2 `downloadBootstrapper`（silent） | `tauri.windows.conf.json`（`allowDowngrades: false`）+ `tauri.bundle.conf.json`（`externalBin`） | 原生 CI 构建、静默安装/卸载、冻结 sidecar、restore/recover、隐私、GUI 进程与单实例 smoke 通过；source-CLI launcher 迁移/强杀恢复门禁已通过。实体机可见 UI、SmartScreen、无 WebView2 与强杀恢复仍待验收 |
 | Linux | 无 GUI 产物 | 无 | 不支持（CLI 继续支持） |
 
 两种受支持平台都只用 `cd gui && npm run bundle` 生成发行产物。该入口先原生构建 sidecar，再加载打包 overlay 启用 bundle 和 `externalBin`；裸 Tauri 构建不是发行打包入口。
@@ -18,7 +18,7 @@
 以下事项直接决定未签名 beta 能否外发，不得在取得证据前表述为已完成：
 
 1. **macOS beta 验收**：GUI Dashboard、Deploy、Manage、操作中关闭与真实进程强杀恢复 E2E 已完成；仍需记录带 quarantine 的 Gatekeeper 用户视角提示及人工安装步骤。
-2. **Windows 原生验收**：GitHub 托管 runner 已通过 sidecar/NSIS 构建、静默 install/uninstall、PowerShell wrapper、restore/recover、隐私、GUI 进程、单实例、超时杀树与输出超限，并将旧 launcher 迁移/首次移动后强杀恢复作为 source-CLI 门禁；仍需 Windows 实体机完成可见 UI、操作中关闭、旧 launcher、事务强杀恢复、无 WebView2 与 SmartScreen 提示。
+2. **Windows 原生验收**：GitHub 托管 runner 已通过 sidecar/NSIS 构建、静默 install/uninstall、PowerShell wrapper、restore/recover、隐私、GUI 进程、单实例、超时杀树与输出超限；旧 launcher 迁移/首次移动后强杀恢复的 source-CLI 门禁亦已通过（CI run `31810727817`）。仍需 Windows 实体机完成可见 UI、操作中关闭、旧 launcher、事务强杀恢复、无 WebView2 与 SmartScreen 提示。
 3. **候选可追溯性**：PR 验证 artifact 固定为 `release_eligible:false`；合并后必须从精确 main SHA 重新生成两端 `release_eligible:true` 候选，并复核安装器、sidecar、`BUILD_INFO.json`、LF-only `SHA256SUMS`、版本、source commit、目标架构及签名状态。
 4. **发布授权**：本轮可以完成分支、PR、合并与候选 artifact；创建 tag / GitHub Release 前必须停下取得明确授权。
 

--- a/docs/release-notes-drafts.md
+++ b/docs/release-notes-drafts.md
@@ -38,7 +38,7 @@ CLI 稳定性与可编程性版本。
 
 - 页面：Dashboard（sidecar 探测 / 状态）、三步 Deploy 向导、Manage（uninstall / 受控备份 restore / recover / repair）、Settings（zh-CN / en）。
 - 每一步写操作都走 CLI JSON 契约的 preview → confirm → execute，失败关闭：超时杀整棵进程树、输出超限拒绝解析、全局写互斥、关闭窗口排队等待在途操作。Manage restore 使用 `backups --json` 返回的绝对目标路径并由 CLI 复核 scope 内 target / backup 精确配对。
-- 目标产物：macOS Apple Silicon `.dmg`；Windows x64 NSIS currentUser 安装器 + WebView2 bootstrapper。Windows 原生 CI 构建、静默安装/卸载、冻结 sidecar、PowerShell wrapper、restore/recover、隐私、GUI 进程与单实例 smoke 已通过；实体机可见 UI、SmartScreen、无 WebView2 与事务强杀恢复仍待验收。
+- 目标产物：macOS Apple Silicon `.dmg`；Windows x64 NSIS currentUser 安装器 + WebView2 bootstrapper。Windows 原生 CI 构建、静默安装/卸载、冻结 sidecar、PowerShell wrapper、restore/recover、隐私、GUI 进程与单实例 smoke 已通过；旧 launcher 迁移/强杀恢复为 source-CLI 自动门禁。实体机可见 UI、SmartScreen、无 WebView2 与事务强杀恢复仍待验收。
 
 **本次 beta 已接受的限制（重要）**：
 
@@ -48,7 +48,7 @@ CLI 稳定性与可编程性版本。
 
 **发布门禁**：
 
-- [`beta-acceptance.md`](beta-acceptance.md) 第二节全部未完成条目必须完成并留存证据。macOS GUI UI 与真实进程强杀恢复 E2E 已通过；Windows 原生自动化链已通过，剩余门禁集中在 Gatekeeper、真实 Claude 升级与 Windows 实体机用户视角/强杀恢复。
+- [`beta-acceptance.md`](beta-acceptance.md) 第二节全部未完成条目必须完成并留存证据。macOS GUI UI 与真实进程强杀恢复 E2E 已通过；Windows 原生自动化链已通过，source-CLI launcher 恢复测试已纳入候选 workflow，待本 PR Windows CI 取证；其余门禁集中在 Gatekeeper、用户安装的 Claude 升级与 Windows 实体机用户视角/强杀恢复。
 - 两个平台仅发布实际通过验收的 main 候选，且 `release_eligible:true`，`BUILD_INFO.json` / LF-only `SHA256SUMS` 与安装器、sidecar 一致；tag、Release 与外发仍需单独明确授权。
 - 发现问题请开 issue。
 

--- a/docs/release-notes-drafts.md
+++ b/docs/release-notes-drafts.md
@@ -48,7 +48,7 @@ CLI 稳定性与可编程性版本。
 
 **发布门禁**：
 
-- [`beta-acceptance.md`](beta-acceptance.md) 第二节全部未完成条目必须完成并留存证据。macOS GUI UI 与真实进程强杀恢复 E2E 已通过；Windows 原生自动化链已通过，source-CLI launcher 恢复测试已纳入候选 workflow，待本 PR Windows CI 取证；其余门禁集中在 Gatekeeper、用户安装的 Claude 升级与 Windows 实体机用户视角/强杀恢复。
+- [`beta-acceptance.md`](beta-acceptance.md) 第二节全部未完成条目必须完成并留存证据。macOS GUI UI 与真实进程强杀恢复 E2E 已通过；Windows 原生自动化链及 source-CLI launcher 恢复门禁已在 CI run `31810727817` 通过；其余门禁集中在 Gatekeeper、用户安装的 Claude 升级与 Windows 实体机用户视角/强杀恢复。
 - 两个平台仅发布实际通过验收的 main 候选，且 `release_eligible:true`，`BUILD_INFO.json` / LF-only `SHA256SUMS` 与安装器、sidecar 一致；tag、Release 与外发仍需单独明确授权。
 - 发现问题请开 issue。
 

--- a/docs/transaction-recovery.md
+++ b/docs/transaction-recovery.md
@@ -40,13 +40,13 @@ journal 在每次真实写入前创建，**每个 mutation 前后都原子落盘
 
 记录内容：`journal_id`（uuid hex）、`operation`、`scope`、`scope_root`、`pid`、`started_at`/`committed_at`、`state`，以及：
 
-- `steps[]`：每步 `{action: backup|write|remove|migrate, path, before: {sha256,size_bytes,exists}, after: {...}, backup_path?, at}`；`migrate` 步骤额外记录 `moved: [[source, backup], ...]`（Windows 旧 launcher 迁移）。
+- `steps[]`：每步 `{action: backup|write|remove|migrate, path, before: {sha256,size_bytes,exists}, after: {...}, backup_path?, at}`；`migrate` 在任何 rename 前额外持久化 `migration_items: [{source,backup,before}, ...]`，每次成功移动后再追加兼容字段 `moved: [[source, backup], ...]`。
 - `backups[]`：备份证据 `{target, backup_path, sha256, size_bytes, created}`。
 
 两阶段语义：
 
-- **commit 成功前中断（state=pending）** ⇒ 下次写入或 `recover` 时**逆序回滚**：文件当前指纹匹配 after ⇒ 用备份/旧内容恢复 before 状态；before 不存在（事务新建文件）⇒ 删除；当前指纹仍等于 before（写入未生效）⇒ 跳过。`migrate` 步骤逆序把备份 rename 回原路径。
-- **commit 成功后中断（state=committed）** ⇒ **永不反转**。只做残留核验（例如已提交迁移的目标被意外重建则报告 blocker），核验干净后消费掉 journal。这就是"crash-after-commit 窗口"：`journal.finish()` 删除失败或进程死在 commit 与 finish 之间时，下一次写入会在锁内核验该 committed journal 无残留后直接消费，不阻塞。
+- **commit 成功前中断（state=pending）** ⇒ 下次写入或 `recover` 时**逆序回滚**：文件当前指纹匹配 after ⇒ 用备份/旧内容恢复 before 状态；before 不存在（事务新建文件）⇒ 删除；当前指纹仍等于 before（写入未生效）⇒ 跳过。`migrate` 通过 rename 前已落盘的 source / backup 路径与源指纹判断移动是否发生，只恢复匹配备份，且使用 no-overwrite 移动；Windows 原子 rename 后、POSIX hard-link 与 unlink 之间或之后被强杀都可恢复。
+- **commit 成功后中断（state=committed）** ⇒ **永不反转**。只做残留核验（迁移目标不得被重建，迁移备份仍必须匹配 commit 前持久化的 source 指纹），核验干净后消费掉 journal。这就是"crash-after-commit 窗口"：`journal.finish()` 删除失败或进程死在 commit 与 finish 之间时，下一次写入会在锁内核验该 committed journal 无残留后直接消费，不阻塞。
 
 回滚定位 before 内容的顺序：优先使用步骤记录的 `backup_path`（校验其 sha256 等于 before）；缺失时在同目录的 `<name>.bak_*` 候选中找指纹匹配者；都找不到 ⇒ blocker，保留证据。
 
@@ -72,6 +72,7 @@ preview 模式（无 `--yes`）完全不触碰文件系统，不检查门槛、�
 - `remove` 步骤的目标被未知方重建（存在但指纹不等于 before）⇒ 拒绝覆盖。
 - 找不到匹配 before 指纹的备份 ⇒ 回滚受阻。
 - 迁移备份缺失 ⇒ 无法回滚该迁移。
+- 迁移 source / backup 同时存在但不是 POSIX 同一 hard-link inode ⇒ 视为外部同名竞态，保留两者并阻塞；不会仅凭内容相同删除文件。
 - 未知的 journal 步骤类型 ⇒ 保留证据并阻塞。
 - 活跃的他方锁（live PID）。
 - 损坏的 journal ⇒ 保留证据并阻塞。

--- a/gui/SPEC.md
+++ b/gui/SPEC.md
@@ -103,7 +103,7 @@ localStorage 单键 `claude-keysmith-gui:settings`：`cliPath`（留空 = 自动
 - 构建环境净化：`PYTHONNOUSERSITE=1`，删除 `PYTHONHOME` / `PYTHONPATH` / `PYTHONUSERBASE`；`PYTHON` 环境变量指定解释器（需 `pip install -r requirements-build.txt`）。
 - 产物原子落位 `src-tauri/binaries/claude-keysmith-cli-<triple>[.exe]`（先复制到临时名再 rename，Unix 下 `chmod 755`），随后 `--version` smoke，失败即构建失败。
 - `npm run bundle` 是唯一打包入口：先构建 sidecar，再加载 `tauri.bundle.conf.json` 启用 bundle 并声明 `externalBin`。常驻配置 `bundle.active=false`，裸 `tauri build` 只产 executable；即使显式传 `--bundles`，默认 `beforeBundleCommand` 也会拒绝。overlay 覆盖该 hook 后仍按 `TAURI_ENV_TARGET_TRIPLE` 校验目标 sidecar 存在且可执行。
-- macOS 目标由 `tauri.macos.conf.json` 声明 `app` + `dmg`；Windows 由 `tauri.windows.conf.json` 声明 NSIS currentUser + WebView2 downloadBootstrapper。Windows 原生 CI 已覆盖构建、静默安装/卸载、冻结 sidecar、PowerShell wrapper、restore/recover、隐私、GUI 进程与单实例；实体机可见 UI、SmartScreen、无 WebView2 与事务强杀恢复状态见发布验收文档。
+- macOS 目标由 `tauri.macos.conf.json` 声明 `app` + `dmg`；Windows 由 `tauri.windows.conf.json` 声明 NSIS currentUser + WebView2 downloadBootstrapper。Windows 原生 CI 已覆盖构建、静默安装/卸载、冻结 sidecar、PowerShell wrapper、restore/recover、隐私、GUI 进程与单实例，并在 source CLI 层覆盖旧 launcher 迁移/强杀恢复；实体机可见 UI、SmartScreen、无 WebView2 与事务强杀恢复状态见发布验收文档。
 
 ## 9. 不变量（改动必须保持）
 

--- a/tests/test_claude_instruct.py
+++ b/tests/test_claude_instruct.py
@@ -396,6 +396,115 @@ def test_runtime_install_user_scope_writes_prompts_settings_and_wrapper(tmp_path
     assert '"runtime_ready": true' in status.stdout or '"runtime_ready": true' in status.stdout.replace("True", "true")
 
 
+@pytest.mark.skipif(os.name == "nt", reason="zsh runtime is not supported on Windows")
+def test_zsh_runtime_status_accepts_missing_stale_fast_path_after_upgrade(tmp_path):
+    home = tmp_path / "home"
+    first_bin = tmp_path / "versions" / "1" / "bin"
+    second_bin = tmp_path / "versions" / "2" / "bin"
+    first_bin.mkdir(parents=True)
+    second_bin.mkdir(parents=True)
+    first_claude = first_bin / "claude"
+    second_claude = second_bin / "claude"
+    first_claude.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    second_claude.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    first_claude.chmod(0o755)
+    second_claude.chmod(0o755)
+    base_path = os.environ.get("PATH", "")
+
+    install = run_cli(
+        ["install", "--scope", "user", "--runtime", "--yes"],
+        home=home,
+        extra_env={
+            "CLAUDE_KEYSMITH_SHELL": "zsh",
+            "PATH": os.pathsep.join((str(first_bin), base_path)),
+        },
+        check=False,
+    )
+    assert install.returncode == 0, install.stdout + install.stderr
+    wrapper = (home / ".zshrc").read_text(encoding="utf-8")
+    assert str(first_claude.resolve()) in wrapper
+
+    first_bin.parent.rename(first_bin.parent.with_name("1.retired"))
+    status = json.loads(
+        run_cli(
+            ["status", "--scope", "user", "--runtime", "--json"],
+            home=home,
+            extra_env={
+                "CLAUDE_KEYSMITH_SHELL": "zsh",
+                "PATH": os.pathsep.join((str(second_bin), base_path)),
+            },
+        ).stdout
+    )["runtime"]
+
+    assert status["upstream_path"] == str(second_claude.resolve())
+    assert status["shell_wrapper_current"] is True
+    assert status["runtime_ready"] is True
+    assert status["upgrade_required"] is False
+
+    zshrc = home / ".zshrc"
+    drifted_wrapper = wrapper.replace("    return 127", "    return 126", 1)
+    assert drifted_wrapper != wrapper
+    zshrc.write_text(drifted_wrapper, encoding="utf-8")
+    drifted_status = json.loads(
+        run_cli(
+            ["status", "--scope", "user", "--runtime", "--json"],
+            home=home,
+            extra_env={
+                "CLAUDE_KEYSMITH_SHELL": "zsh",
+                "PATH": os.pathsep.join((str(second_bin), base_path)),
+            },
+        ).stdout
+    )["runtime"]
+    assert drifted_status["shell_wrapper_current"] is False
+    assert drifted_status["runtime_ready"] is False
+    assert drifted_status["upgrade_required"] is True
+
+    installed_block = claude_instruct.shell_block_pattern().search(wrapper).group(0)
+    expected_block = installed_block.replace(
+        f'  entry="{first_claude.resolve()}"',
+        f'  entry="{second_claude.resolve()}"',
+        1,
+    )
+
+    def block_with_entry(raw):
+        return expected_block.replace(
+            f'  entry="{second_claude.resolve()}"',
+            f'  entry="{raw}"',
+            1,
+        )
+
+    missing_literal = tmp_path / "retired version" / "claude-旧"
+    assert claude_instruct.shell_wrapper_is_current(
+        block_with_entry(missing_literal), expected_block, "zsh"
+    )
+
+    existing_file = tmp_path / "existing-claude"
+    existing_file.write_text("fixture\n", encoding="utf-8")
+    existing_dir = tmp_path / "existing-dir"
+    existing_dir.mkdir()
+    dangling_link = tmp_path / "dangling-claude"
+    dangling_link.symlink_to(tmp_path / "missing-target")
+    rejected_entries = (
+        "claude",
+        "~/retired/claude",
+        f"{tmp_path}/$(id)/claude",
+        f"{tmp_path}/`id`/claude",
+        str(tmp_path / "retired\\version" / "claude"),
+        str(tmp_path / "bad\tname" / "claude"),
+        str(existing_file),
+        str(existing_dir),
+        str(dangling_link),
+    )
+    for raw in rejected_entries:
+        assert not claude_instruct.shell_wrapper_is_current(
+            block_with_entry(raw), expected_block, "zsh"
+        )
+
+    assert not claude_instruct.shell_wrapper_is_current(
+        installed_block, expected_block, "powershell"
+    )
+
+
 def test_runtime_install_sets_max_tokens_only_when_explicit(tmp_path):
     home = tmp_path / "home"
     claude_dir = home / ".claude"
@@ -843,6 +952,33 @@ def test_legacy_launcher_migration_never_overwrites_preoccupied_backup(tmp_path)
     assert not legacy_cmd.exists()
 
 
+def test_legacy_launcher_migration_preserves_same_content_backup_raced_after_plan(tmp_path):
+    home = tmp_path / "home"
+    local_bin = home / ".local" / "bin"
+    local_bin.mkdir(parents=True)
+    legacy_ps1 = local_bin / "claude.ps1"
+    legacy_cmd = local_bin / "claude.cmd"
+    ps1_content = "# claude-keysmith\n$systemPrompt = 'system-prompt'\n"
+    legacy_ps1.write_text(ps1_content, encoding="utf-8")
+    legacy_cmd.write_bytes(
+        b'@echo off\r\npowershell.exe -File "%~dp0claude.ps1" %*\r\n'
+    )
+    plan = claude_instruct.plan_legacy_launcher_migration(home, "20260807_120000")
+    raced_backup = Path(plan[0]["backup"])
+    raced_backup.write_text(ps1_content, encoding="utf-8")
+
+    with pytest.raises(FileExistsError, match="拒绝覆盖"):
+        claude_instruct.migrate_legacy_launchers(
+            home,
+            "20260807_120000",
+            migration_plan=plan,
+        )
+
+    assert legacy_ps1.read_text(encoding="utf-8") == ps1_content
+    assert raced_backup.read_text(encoding="utf-8") == ps1_content
+    assert legacy_cmd.exists()
+
+
 def test_legacy_launcher_migration_rolls_back_first_file_when_second_move_fails(
     tmp_path, monkeypatch
 ):
@@ -855,14 +991,14 @@ def test_legacy_launcher_migration_rolls_back_first_file_when_second_move_fails(
     cmd_content = '@echo off\r\npowershell.exe -File "%~dp0claude.ps1" %*\r\n'
     legacy_ps1.write_text(ps1_content, encoding="utf-8")
     legacy_cmd.write_bytes(cmd_content.encode("utf-8"))
-    real_replace = claude_instruct.os.replace
+    real_move = claude_instruct._move_file_no_overwrite
 
     def fail_cmd_migration(source, target):
         if Path(source) == legacy_cmd and ".bak_20260807_120000_pre_v6" in str(target):
             raise OSError("cmd migration failed")
-        return real_replace(source, target)
+        return real_move(Path(source), Path(target))
 
-    monkeypatch.setattr(claude_instruct.os, "replace", fail_cmd_migration)
+    monkeypatch.setattr(claude_instruct, "_move_file_no_overwrite", fail_cmd_migration)
 
     with pytest.raises(OSError, match="cmd migration failed"):
         claude_instruct.migrate_legacy_launchers(home, "20260807_120000")
@@ -871,6 +1007,34 @@ def test_legacy_launcher_migration_rolls_back_first_file_when_second_move_fails(
     assert legacy_cmd.read_bytes() == cmd_content.encode("utf-8")
     assert not list(local_bin.glob("claude.ps1.bak_*_pre_v6*"))
     assert not list(local_bin.glob("claude.cmd.bak_*_pre_v6*"))
+
+
+@pytest.mark.skipif(os.name == "nt", reason="creating symlinks is not reliably permitted on Windows runners")
+def test_runtime_install_refuses_dangling_legacy_launcher_symlink_before_any_write(tmp_path):
+    home = tmp_path / "home"
+    profile = home / "profile.ps1"
+    upstream = tmp_path / "upstream" / "claude.exe"
+    upstream.parent.mkdir(parents=True)
+    upstream.write_bytes(b"fixture")
+    dangling = home / ".local" / "bin" / "claude.ps1"
+    dangling.parent.mkdir(parents=True)
+    dangling.symlink_to(dangling.parent / "missing-upstream.ps1")
+    env = windows_runtime_env(home, profile, CLAUDE_KEYSMITH_CLAUDE_BIN=upstream)
+
+    result = run_cli(
+        ["install", "--scope", "user", "--runtime", "--yes", "--json"],
+        home=home,
+        extra_env=env,
+        check=False,
+    )
+
+    payload = json.loads(result.stdout)
+    assert result.returncode == 1
+    assert payload["ok"] is False
+    assert "拒绝" in payload["error"]
+    assert dangling.is_symlink()
+    assert not (home / ".claude").exists()
+    assert not profile.exists()
 
 
 def test_runtime_install_refuses_unknown_local_bin_launcher_before_any_write(tmp_path):

--- a/tests/test_json_contract.py
+++ b/tests/test_json_contract.py
@@ -424,6 +424,24 @@ def test_backups_json_enumerates_only_keysmith_scheme(tmp_path):
     assert any(name.startswith("CLAUDE.md.bak_") for name in names)
 
 
+def test_backups_json_never_leaks_backup_contents_or_credentials(tmp_path):
+    home = tmp_path / "home"
+    keysmith_dir = home / ".claude" / "keysmith"
+    keysmith_dir.mkdir(parents=True)
+    sentinel = "TOKEN_SENTINEL_backup_content_deadbeef"
+    backup = keysmith_dir / "rules.md.bak_20260814_120000"
+    backup.write_text(sentinel + "\n", encoding="utf-8")
+
+    result = run_cli(["backups", "--scope", "user", "--json"], home=home)
+    payload = parse_json(result)
+
+    assert payload["ok"] is True
+    assert sentinel not in result.stdout
+    assert payload["backups"]
+    assert all("content" not in entry for entry in payload["backups"])
+    assert any(entry["backup_path"] == str(backup) for entry in payload["backups"])
+
+
 def test_backups_project_scope_filter(tmp_path):
     home = tmp_path / "home"
     project = tmp_path / "repo"

--- a/tests/test_transaction_recovery.py
+++ b/tests/test_transaction_recovery.py
@@ -5,6 +5,7 @@ import os
 import subprocess
 import sys
 import threading
+import time
 from pathlib import Path
 
 import importlib.util
@@ -28,6 +29,9 @@ def run_cli(args, *, home, cwd=None, check=True, extra_env=None):
         "CLAUDE_KEYSMITH_CLAUDE_BIN",
     ):
         env.pop(key, None)
+    # macOS framework Python can put bytecode caches under HOME; keep the
+    # interpreter's own files outside the tree whose read-only semantics we test.
+    env["PYTHONPYCACHEPREFIX"] = str(home.parent / ".python-cache")
     if extra_env:
         env.update(extra_env)
     return subprocess.run(
@@ -698,6 +702,58 @@ def test_committed_journal_is_never_reversed(tmp_path, monkeypatch):
     assert not journal.path.exists()
 
 
+def test_committed_launcher_migration_is_never_reversed(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    monkeypatch.setenv("CLAUDE_KEYSMITH_HOME", str(home))
+    paths = claude_instruct.resolve_scope("user")
+    local_bin = home / ".local" / "bin"
+    local_bin.mkdir(parents=True)
+    source = local_bin / "claude.ps1"
+    backup = local_bin / "claude.ps1.bak_20260814_120000_pre_v6"
+    source.write_text("# claude-keysmith\n$systemPrompt = 'system-prompt'\n", encoding="utf-8")
+    before = claude_instruct.file_evidence(source)
+    claude_instruct._move_file_no_overwrite(source, backup)
+
+    journal = claude_instruct.TransactionJournal(paths, "install")
+    journal.log_step(
+        {
+            "action": "migrate",
+            "path": str(local_bin),
+            "before": claude_instruct.file_evidence(local_bin),
+            "after": claude_instruct.file_evidence(local_bin),
+            "moved": [[str(source), str(backup)]],
+            "migration_items": [
+                {"source": str(source), "backup": str(backup), "before": before}
+            ],
+        }
+    )
+    journal.commit()
+
+    actions, blockers = claude_instruct.finish_committed_journal(journal.record)
+    assert actions
+    assert blockers == []
+    original_backup = backup.read_bytes()
+    backup.write_text("tampered after commit\n", encoding="utf-8")
+    actions, blockers = claude_instruct.finish_committed_journal(journal.record)
+    assert actions == []
+    assert any("备份指纹异常" in item for item in blockers)
+    backup.write_bytes(original_backup)
+
+    malformed_record = json.loads(json.dumps(journal.record))
+    malformed_record["steps"][0]["migration_items"] = [None]
+    actions, blockers = claude_instruct.finish_committed_journal(malformed_record)
+    assert actions == []
+    assert any("证据格式无效" in item for item in blockers)
+
+    payload = json.loads(
+        run_cli(["recover", "--scope", "user", "--yes", "--json"], home=home).stdout
+    )
+    assert payload["ok"] is True
+    assert not source.exists()
+    assert backup.is_file()
+    assert not journal.path.exists()
+
+
 def test_crash_after_commit_window_is_consumed_by_next_write(tmp_path, monkeypatch):
     """A committed journal with a dead holder (crash before cleanup) must not
     permanently block the next write; the write consumes it after verifying the
@@ -719,6 +775,341 @@ def test_crash_after_commit_window_is_consumed_by_next_write(tmp_path, monkeypat
 
 
 # --------------------------------------------------- mid-transaction crash --
+
+
+def test_forced_kill_after_first_legacy_launcher_move_recovers_exactly(tmp_path):
+    home = tmp_path / "home"
+    keysmith_dir = home / ".claude" / "keysmith"
+    local_bin = home / ".local" / "bin"
+    profile = home / "Documents" / "PowerShell" / "Microsoft.PowerShell_profile.ps1"
+    upstream = tmp_path / "upstream" / "claude.exe"
+    barrier = tmp_path / "first-launcher-moved"
+    keysmith_dir.mkdir(parents=True)
+    local_bin.mkdir(parents=True)
+    profile.parent.mkdir(parents=True)
+    upstream.parent.mkdir(parents=True)
+    upstream.write_bytes(b"fixture")
+
+    legacy_ps1 = local_bin / "claude.ps1"
+    legacy_cmd = local_bin / "claude.cmd"
+    ps1_content = "# claude-keysmith\n$systemPrompt = 'system-prompt'\n"
+    cmd_content = '@echo off\r\npowershell.exe -File "%~dp0claude.ps1" %*\r\n'
+    legacy_ps1.write_text(ps1_content, encoding="utf-8")
+    legacy_cmd.write_bytes(cmd_content.encode("utf-8"))
+
+    baseline = snapshot_tree(home)
+    child_code = r"""
+import importlib.util
+import sys
+import time
+from pathlib import Path
+
+module_path = Path(sys.argv[1])
+barrier = Path(sys.argv[2])
+spec = importlib.util.spec_from_file_location("claude_instruct_kill_fixture", module_path)
+module = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+real_move = module._move_file_no_overwrite
+move_count = 0
+
+def pause_after_first_move(source, target):
+    global move_count
+    real_move(source, target)
+    move_count += 1
+    if move_count == 1:
+        barrier.write_text("moved\n", encoding="utf-8")
+        while True:
+            time.sleep(1)
+
+module._move_file_no_overwrite = pause_after_first_move
+sys.argv = [
+    str(module_path),
+    "install",
+    "--scope",
+    "user",
+    "--runtime",
+    "--yes",
+    "--json",
+]
+raise SystemExit(module.main())
+"""
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": str(home),
+            "CLAUDE_KEYSMITH_HOME": str(home),
+            "CLAUDE_KEYSMITH_SHELL": "powershell",
+            "CLAUDE_KEYSMITH_SHELL_RC": str(profile),
+            "CLAUDE_KEYSMITH_CLAUDE_BIN": str(upstream),
+            "APPDATA": str(home / "AppData" / "Roaming"),
+            "PYTHONPYCACHEPREFIX": str(tmp_path / ".python-cache"),
+        }
+    )
+    env.pop("CLAUDE_CONFIG_DIR", None)
+
+    child = subprocess.Popen(
+        [sys.executable, "-c", child_code, str(MODULE_PATH), str(barrier)],
+        env=env,
+        text=True,
+        encoding="utf-8",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    deadline = time.monotonic() + 20
+    while not barrier.exists() and child.poll() is None and time.monotonic() < deadline:
+        time.sleep(0.05)
+    if not barrier.exists():
+        stdout, stderr = child.communicate(timeout=5)
+        pytest.fail(f"child did not reach migration barrier: {stdout}\n{stderr}")
+
+    child.kill()
+    child.wait(timeout=10)
+    assert child.returncode != 0
+    assert not legacy_ps1.exists()
+    assert legacy_cmd.read_bytes() == cmd_content.encode("utf-8")
+    assert list(local_bin.glob("claude.ps1.bak_*_pre_v6*"))
+
+    journals = list(keysmith_dir.glob(".journal-*.json"))
+    assert len(journals) == 1
+    journal_record = json.loads(journals[0].read_text(encoding="utf-8"))
+    migrate_step = next(step for step in journal_record["steps"] if step["action"] == "migrate")
+    assert len(migrate_step["migration_items"]) == 2
+    assert migrate_step["moved"] == []  # kill happened before after-move progress persisted
+
+    blocked = run_cli(
+        ["install", "--scope", "user", "--runtime", "--yes", "--json"],
+        home=home,
+        extra_env={
+            "CLAUDE_KEYSMITH_SHELL": "powershell",
+            "CLAUDE_KEYSMITH_SHELL_RC": str(profile),
+            "CLAUDE_KEYSMITH_CLAUDE_BIN": str(upstream),
+        },
+        check=False,
+    )
+    assert blocked.returncode == 1
+    assert json.loads(blocked.stdout)["ok"] is False
+
+    before_preview = snapshot_tree(home)
+    preview = run_cli(["recover", "--scope", "user", "--json"], home=home)
+    preview_payload = json.loads(preview.stdout)
+    assert preview_payload["ok"] is True
+    assert any(item["action"] == "restore-moved" for item in preview_payload["planned_repairs"])
+    assert snapshot_tree(home) == before_preview
+
+    execute = run_cli(["recover", "--scope", "user", "--yes", "--json"], home=home)
+    execute_payload = json.loads(execute.stdout)
+    assert execute_payload["ok"] is True
+    assert legacy_ps1.read_text(encoding="utf-8") == ps1_content
+    assert legacy_cmd.read_bytes() == cmd_content.encode("utf-8")
+    assert not list(local_bin.glob("claude.*.bak_*_pre_v6*"))
+    assert not list(keysmith_dir.glob(".journal-*.json"))
+    assert not (keysmith_dir / ".keysmith.lock").exists()
+
+    final = snapshot_tree(home)
+
+    def controlled_state(tree):
+        prefixes = (".claude", ".local", "Documents")
+        return {
+            key: (value[0], value[1])
+            for key, value in tree.items()
+            if key == "." or any(key == prefix or key.startswith(prefix + os.sep) for prefix in prefixes)
+        }
+
+    # macOS may let the Python runtime create its own ~/Library cache tree;
+    # keysmith-controlled paths must still return byte-for-byte to baseline.
+    assert controlled_state(final) == controlled_state(baseline)
+
+
+def test_live_launcher_migration_rejects_source_replacement_after_precheck(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / "home"
+    monkeypatch.setenv("CLAUDE_KEYSMITH_HOME", str(home))
+    paths = claude_instruct.resolve_scope("user")
+    local_bin = home / ".local" / "bin"
+    local_bin.mkdir(parents=True)
+    source = local_bin / "claude.ps1"
+    cmd = local_bin / "claude.cmd"
+    original = "# claude-keysmith\n$systemPrompt = 'system-prompt'\n"
+    replacement = "third-party replacement\n"
+    source.write_text(original, encoding="utf-8")
+    cmd.write_bytes(b'@echo off\r\npowershell.exe -File "%~dp0claude.ps1" %*\r\n')
+
+    journal = claude_instruct.TransactionJournal(paths, "install")
+    real_move = claude_instruct._move_file_no_overwrite
+
+    def replace_source_after_precheck(move_source, target):
+        if Path(move_source) == source:
+            source.write_text(replacement, encoding="utf-8")
+        real_move(Path(move_source), Path(target))
+
+    monkeypatch.setattr(
+        claude_instruct, "_move_file_no_overwrite", replace_source_after_precheck
+    )
+    with pytest.raises(OSError, match="迁移失败且回滚不完整"):
+        claude_instruct.tx_migrate_legacy_launchers(
+            journal, home, "20260814_120000"
+        )
+
+    journal_record = json.loads(journal.path.read_text(encoding="utf-8"))
+    migrate_step = next(
+        step for step in journal_record["steps"] if step["action"] == "migrate"
+    )
+    backup = Path(migrate_step["migration_items"][0]["backup"])
+    assert migrate_step["moved"] == []
+    assert not source.exists()
+    assert backup.read_text(encoding="utf-8") == replacement
+    assert cmd.exists()
+
+    before_preview = snapshot_tree(home)
+    preview = run_cli(["recover", "--scope", "user", "--json"], home=home, check=False)
+    preview_payload = json.loads(preview.stdout)
+    assert preview.returncode == 1
+    assert preview_payload["ok"] is False
+    assert any("指纹不匹配" in item for item in preview_payload["blockers"])
+    assert snapshot_tree(home) == before_preview
+
+    execute = run_cli(
+        ["recover", "--scope", "user", "--yes", "--json"],
+        home=home,
+        check=False,
+    )
+    execute_payload = json.loads(execute.stdout)
+    assert execute.returncode == 1
+    assert execute_payload["blockers"] == preview_payload["blockers"]
+    assert not source.exists()
+    assert backup.read_text(encoding="utf-8") == replacement
+    assert cmd.exists()
+    assert journal.path.exists()
+
+
+def test_pending_launcher_migration_preserves_same_content_distinct_backup(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    monkeypatch.setenv("CLAUDE_KEYSMITH_HOME", str(home))
+    paths = claude_instruct.resolve_scope("user")
+    local_bin = home / ".local" / "bin"
+    local_bin.mkdir(parents=True)
+    source = local_bin / "claude.ps1"
+    backup = local_bin / "claude.ps1.bak_20260814_120000_pre_v6"
+    content = "# claude-keysmith\n$systemPrompt = 'system-prompt'\n"
+    source.write_text(content, encoding="utf-8")
+    before = claude_instruct.file_evidence(source)
+    backup.write_text(content, encoding="utf-8")  # same bytes, different file identity
+
+    journal = claude_instruct.TransactionJournal(paths, "install")
+    journal.log_step(
+        {
+            "action": "migrate",
+            "path": str(local_bin),
+            "before": claude_instruct.file_evidence(local_bin),
+            "after": {},
+            "moved": [],
+            "migration_items": [
+                {"source": str(source), "backup": str(backup), "before": before}
+            ],
+        }
+    )
+
+    before_preview = snapshot_tree(home)
+    preview = run_cli(["recover", "--scope", "user", "--json"], home=home, check=False)
+    preview_payload = json.loads(preview.stdout)
+    assert preview.returncode == 1
+    assert any("身份不同" in item for item in preview_payload["blockers"])
+    assert snapshot_tree(home) == before_preview
+
+    execute = run_cli(
+        ["recover", "--scope", "user", "--yes", "--json"],
+        home=home,
+        check=False,
+    )
+    assert execute.returncode == 1
+    assert source.read_text(encoding="utf-8") == content
+    assert backup.read_text(encoding="utf-8") == content
+    assert journal.path.exists()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX migration uses a hard-link transition")
+def test_pending_launcher_migration_cleans_same_inode_transition(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    monkeypatch.setenv("CLAUDE_KEYSMITH_HOME", str(home))
+    paths = claude_instruct.resolve_scope("user")
+    local_bin = home / ".local" / "bin"
+    local_bin.mkdir(parents=True)
+    source = local_bin / "claude.ps1"
+    backup = local_bin / "claude.ps1.bak_20260814_120000_pre_v6"
+    content = "# claude-keysmith\n$systemPrompt = 'system-prompt'\n"
+    source.write_text(content, encoding="utf-8")
+    before = claude_instruct.file_evidence(source)
+    os.link(str(source), str(backup))
+    assert os.path.samestat(source.stat(), backup.stat())
+
+    journal = claude_instruct.TransactionJournal(paths, "install")
+    journal.log_step(
+        {
+            "action": "migrate",
+            "path": str(local_bin),
+            "before": claude_instruct.file_evidence(local_bin),
+            "after": {},
+            "moved": [],
+            "migration_items": [
+                {"source": str(source), "backup": str(backup), "before": before}
+            ],
+        }
+    )
+
+    preview_payload = json.loads(
+        run_cli(["recover", "--scope", "user", "--json"], home=home).stdout
+    )
+    assert preview_payload["ok"] is True
+    assert any(item["action"] == "cleanup" for item in preview_payload["planned_repairs"])
+    assert source.exists() and backup.exists()
+
+    execute_payload = json.loads(
+        run_cli(["recover", "--scope", "user", "--yes", "--json"], home=home).stdout
+    )
+    assert execute_payload["ok"] is True
+    assert source.read_text(encoding="utf-8") == content
+    assert not backup.exists()
+    assert not journal.path.exists()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX recovery uses a hard-link transition")
+def test_old_moved_only_journal_cleans_interrupted_recovery_hard_link(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    monkeypatch.setenv("CLAUDE_KEYSMITH_HOME", str(home))
+    paths = claude_instruct.resolve_scope("user")
+    local_bin = home / ".local" / "bin"
+    local_bin.mkdir(parents=True)
+    source = local_bin / "claude.ps1"
+    backup = local_bin / "claude.ps1.bak_20260814_120000_pre_v6"
+    backup.write_text("# claude-keysmith\n$systemPrompt = 'system-prompt'\n", encoding="utf-8")
+    os.link(str(backup), str(source))
+
+    journal = claude_instruct.TransactionJournal(paths, "install")
+    journal.log_step(
+        {
+            "action": "migrate",
+            "path": str(local_bin),
+            "before": claude_instruct.file_evidence(local_bin),
+            "after": {},
+            "moved": [[str(source), str(backup)]],
+        }
+    )
+
+    preview_payload = json.loads(
+        run_cli(["recover", "--scope", "user", "--json"], home=home).stdout
+    )
+    assert preview_payload["ok"] is True
+    assert any(item["action"] == "cleanup" for item in preview_payload["planned_repairs"])
+
+    execute_payload = json.loads(
+        run_cli(["recover", "--scope", "user", "--yes", "--json"], home=home).stdout
+    )
+    assert execute_payload["ok"] is True
+    assert source.is_file()
+    assert not backup.exists()
+    assert not journal.path.exists()
 
 
 def test_install_failure_rolls_back_and_recovers_clean(tmp_path, monkeypatch):


### PR DESCRIPTION
修复 Windows 旧 launcher 首次移动后强杀恢复、zsh 升级状态误判，并收紧候选证据与回归门禁。