### PR TITLE
gui: 深色主题回归 Codex tech blue

### DIFF
--- a/.github/workflows/gui-release-candidate.yml
+++ b/.github/workflows/gui-release-candidate.yml
@@ -334,8 +334,17 @@ jobs:
           }
           $firstGui.Refresh()
           if ($firstGui.HasExited) { throw 'first GUI instance exited when the second instance started' }
-          Stop-Process -Id $firstGui.Id -Force
-          $firstGui.WaitForExit()
+          # WebView2 starts utility/GPU descendants that can keep files open
+          # after the top-level Tauri process exits. Kill only this GUI's tree
+          # before asking NSIS to remove the install directory.
+          & taskkill.exe /PID $firstGui.Id /T /F | Out-Null
+          if ($LASTEXITCODE -ne 0) { throw "failed to terminate installed GUI process tree for PID $($firstGui.Id): exit code $LASTEXITCODE" }
+          for ($attempt = 0; $attempt -lt 30; $attempt++) {
+            $firstGui.Refresh()
+            if ($firstGui.HasExited) { break }
+            Start-Sleep -Milliseconds 200
+          }
+          if (-not $firstGui.HasExited) { throw "installed GUI process survived process-tree termination: PID $($firstGui.Id)" }
 
           $uninstall = Start-Process -FilePath $uninstaller -ArgumentList '/S' -Wait -PassThru
           if ($uninstall.ExitCode -ne 0) { throw "silent NSIS uninstall failed with exit code $($uninstall.ExitCode)" }

--- a/docs/desktop-gui.md
+++ b/docs/desktop-gui.md
@@ -54,10 +54,10 @@ Rust 侧只负责"找到 CLI、按 argv 数组启动、限时限量收输出"：
 
 ## 视觉识别
 
-暖陶土（terracotta）+ 米色纸面 + 炭黑，与 codex-keysmith 的蓝紫色系明确区分：
+浅色 clay + 深色 tech blue，与 codex-keysmith 的视觉 token 对齐：
 
 - Light：accent `#d97757`（hover `#c6613f`），纸面底 `#faf9f5`。
-- Dark：暖炭底 `#161311`，accent `#e08a67`（hover `#eea27f`）。
+- Dark：深空黑底 `#0f0f0f`，accent `#6a9bcc`（hover `#8ab4dd`）。
 - muted 文本两主题对比度 ≥ 4.5:1（`--text-muted` 有注释标注）。
 - 玻璃卡片（`backdrop-filter` 模糊 + 24px 点阵纹理）+ 三团环境光晕缓慢漂移（`AmbientBg`，`prefers-reduced-motion` 下静止）。
 

--- a/gui/SPEC.md
+++ b/gui/SPEC.md
@@ -83,13 +83,13 @@ localStorage 单键 `claude-keysmith-gui:settings`：`cliPath`（留空 = 自动
 
 ## 7. 视觉识别
 
-暖陶土 + 米色纸面 + 炭黑（**不是** codex-keysmith 的蓝紫色系）：
+浅色 clay + 深色 tech blue，与 codex-keysmith 的视觉 token 对齐：
 
 | Token | Light | Dark |
 |---|---|---|
-| `--accent` | `#d97757`（hover `#c6613f`） | `#e08a67`（hover `#eea27f`） |
-| `--bg-primary` | `#faf9f5`（米色纸面） | `#161311`（暖炭） |
-| brand 渐变 | `#d97757 → #c6613f → #d4a27f` | `#e08a67 → #c9744f → #d4a27f` |
+| `--accent` | `#d97757`（hover `#c6613f`） | `#6a9bcc`（hover `#8ab4dd`） |
+| `--bg-primary` | `#faf9f5`（米色纸面） | `#0f0f0f`（深空黑） |
+| brand 渐变 | `#d97757 → #c6613f → #d4a27f` | `#6a9bcc → #8b7fcc → #a78bfa` |
 
 - muted 文本两主题对比度 ≥ 4.5:1（`globals.css` 中有注释标注）。
 - 玻璃卡片：`backdrop-filter: blur(16px) saturate(...)` + 24px 点阵纹理 + 内高光。

--- a/gui/src/globals.css
+++ b/gui/src/globals.css
@@ -225,7 +225,7 @@ body {
 }
 
 .dark .card-glass {
-  background-color: rgba(34, 29, 25, 0.5);
+  background-color: color-mix(in srgb, var(--bg-card) 50%, transparent);
   backdrop-filter: blur(16px) saturate(1.3);
   -webkit-backdrop-filter: blur(16px) saturate(1.3);
   box-shadow:

--- a/gui/src/globals.css
+++ b/gui/src/globals.css
@@ -9,7 +9,7 @@
 
 /* ============================================
    claude-keysmith GUI — 双模式 Design System
-   浅色 warm clay / 深色 warm charcoal + terracotta
+   token 沿用 ethanpier.com（浅色 clay / 深色 tech blue）
    ============================================ */
 
 :root {
@@ -48,28 +48,28 @@
 }
 
 .dark {
-  /* ---- Dark: warm charcoal + desaturated terracotta ---- */
-  --bg-primary: #161311;
-  --bg-secondary: #1c1815;
-  --bg-card: #221d19;
-  --bg-elevated: #2b2520;
+  /* ---- Dark: 深空 tech blue ---- */
+  --bg-primary: #0f0f0f;
+  --bg-secondary: #161616;
+  --bg-card: #1a1a1a;
+  --bg-elevated: #252525;
 
-  --text-primary: #f2ede7;
-  --text-secondary: #cec5ba;  /* 4.5:1+ on bg-card */
-  --text-muted: #ada296;      /* 4.5:1+ on bg-primary & bg-card */
+  --text-primary: #f5f5f5;
+  --text-secondary: #c2c2c2;  /* 4.5:1+ on bg-card */
+  --text-muted: #9a9a9a;      /* 4.5:1+ on bg-primary */
 
-  --accent: #e08a67;
-  --accent-hover: #eea27f;
-  --accent-soft: rgba(224, 138, 103, 0.18);
-  --accent-soft-block: rgba(224, 138, 103, 0.12);
+  --accent: #6a9bcc;
+  --accent-hover: #8ab4dd;
+  --accent-soft: rgba(106, 155, 204, 0.18);
+  --accent-soft-block: rgba(106, 155, 204, 0.12);
 
-  --border: #3a332c;
-  --border-hover: #4e453c;
+  --border: #333333;
+  --border-hover: #4a4a4a;
 
-  --glow-color: rgba(224, 138, 103, 0.22);
+  --glow-color: rgba(106, 155, 204, 0.25);
   --shadow-card: 0 0 0 transparent;
   --shadow-card-hover: 0 0 24px var(--glow-color);
-  --gradient-brand: linear-gradient(135deg, #e08a67 0%, #c9744f 50%, #d4a27f 100%);
+  --gradient-brand: linear-gradient(135deg, #6a9bcc 0%, #8b7fcc 50%, #a78bfa 100%);
 
   --ok: #4ade80;
   --warn: #facc15;


### PR DESCRIPTION
## 改动说明

把 claude-keysmith GUI 深色主题从 warm charcoal / terracotta 拉回 Codex Keysmith 标准 tech blue，并修复 Windows x64 NSIS candidate 在卸载阶段的进程清理竞态。

- `.dark` 全套 token：`--bg-primary` `#0f0f0f`、`--accent` `#6a9bcc`、渐变 `#6a9bcc → #8b7fcc → #a78bfa`
- `.dark .card-glass` 使用 `--bg-card` token 混合，避免残留旧暖色硬编码
- Windows GUI smoke 在 NSIS 卸载前使用 `taskkill.exe /PID <GUI PID> /T /F` 清理该 GUI 的完整进程树，等待根进程退出后仍保留安装目录和卸载注册表断言
- 同步 `gui/SPEC.md` 与 `docs/desktop-gui.md` 的视觉 token 说明
- 不改 CLI、bundle identifier、sidecar 名；不合并、不打 tag、不发布

## 验证

- `python3 -m pytest -q tests`：135 passed
- `gui/npm test`：113 passed
- `gui/npm run build`：通过
- `actionlint .github/workflows/gui-release-candidate.yml`：通过
- `git diff --check`：通过
- 已针对失败 run `33149557481` 的实际错误修复：NSIS 卸载成功但 GUI/WebView2 后代仍占用安装目录
