### PR TITLE
release(gui): prepare desktop v0.1.0-beta.2

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -14,7 +14,7 @@ body:
     attributes:
       label: claude-keysmith 版本 / Version
       description: Paste the output of `python3 claude-instruct.py --version`, or the Desktop version.
-      placeholder: claude-keysmith v7.1 or Desktop 0.1.0-beta.1
+      placeholder: claude-keysmith v7.1 or Desktop 0.1.0-beta.2
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 - 重新整理新人安装路径，明确稳定版、预发布版与未签名 Desktop Beta 的区别。
 
+## Desktop 0.1.0-beta.2 (Pre-release)
+
+- 深色主题对齐 Codex tech blue。
+- 修复 Windows 安装/卸载时 WebView2 子进程残留问题。
+- 支持 macOS Apple Silicon 和 Windows x64；未签名、无自动更新。
+
 ## v7 / Desktop 0.1.0-beta.1 (Pre-release)
 
 发布计划：本节内容将以同批次双 Pre-release 发布——`v7`（CLI）与 `desktop-v0.1.0-beta.1`（GUI beta），指向同一最终 main commit；草稿见 [`docs/release-notes-drafts.md`](docs/release-notes-drafts.md)，发布前置门槛见 [`docs/beta-acceptance.md`](docs/beta-acceptance.md)。

--- a/README.en.md
+++ b/README.en.md
@@ -43,7 +43,7 @@ The Keysmith series **deploys, verifies, and revokes** custom instructions for l
 ### Install options
 
 1. **Conservative: stable v7.1 source CLI.** There is no standalone CLI package. Use the command below to clone the `v7.1` tag, then run `claude-instruct.py`. Do not `curl | python`.
-2. **Easier: unsigned Desktop Beta.** See [desktop-v0.1.0-beta.1](https://github.com/Jia-Ethan/claude-keysmith/releases/tag/desktop-v0.1.0-beta.1): macOS Apple Silicon DMG and Windows x64 NSIS, embedding the v7 prerelease CLI. No Linux GUI, no auto-update, no signing. Steps: [`docs/platform-support.md`](docs/platform-support.md).
+2. **Easier: unsigned Desktop Beta.** See [desktop-v0.1.0-beta.2](https://github.com/Jia-Ethan/claude-keysmith/releases/tag/desktop-v0.1.0-beta.2): macOS Apple Silicon DMG and Windows x64 NSIS, embedding the v7.1 CLI. No Linux GUI, no auto-update, no signing. Steps: [`docs/platform-support.md`](docs/platform-support.md).
 
 ### Quick start (stable v7.1)
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Keysmith 系列为本地 AI 工具**安全部署、验证和撤销**自定义指
 ### 安装方式
 
 1. **稳妥：稳定 v7.1 源码 CLI。** 没有独立 CLI 安装包；按下方命令固定 clone `v7.1` tag，再运行 `claude-instruct.py`。不要 `curl | python`。
-2. **更易用：未签名 Desktop Beta。** 见 [desktop-v0.1.0-beta.1](https://github.com/Jia-Ethan/claude-keysmith/releases/tag/desktop-v0.1.0-beta.1)：macOS Apple Silicon DMG 与 Windows x64 NSIS，内嵌 v7 预发布 CLI。无 Linux GUI、无自动更新、无签名。步骤见 [`docs/platform-support.md`](docs/platform-support.md)。
+2. **更易用：未签名 Desktop Beta。** 见 [desktop-v0.1.0-beta.2](https://github.com/Jia-Ethan/claude-keysmith/releases/tag/desktop-v0.1.0-beta.2)：macOS Apple Silicon DMG 与 Windows x64 NSIS，内嵌 v7.1 CLI。无 Linux GUI、无自动更新、无签名。步骤见 [`docs/platform-support.md`](docs/platform-support.md)。
 
 ### 快速开始（稳定 v7.1）
 

--- a/docs/beta-acceptance.md
+++ b/docs/beta-acceptance.md
@@ -1,7 +1,7 @@
 <!-- markdownlint-disable MD013 -->
-# Beta 验收清单（`0.1.0-beta.1`）
+# Beta 验收清单（`0.1.0-beta.2`）
 
-本文区分"已实际取得证据"、"实体机最终验收"与"本次未签名 beta 已接受的限制"。维护者于 2026-08-15 确认第二节全部项目通过；外发 `desktop-v0.1.0-beta.1` 前仍须从精确 main SHA 生成 `release_eligible:true` 候选并取得明确发布授权。代码签名、公证、Authenticode 与自动更新不属于这次明确标记为未签名 beta 的阻塞项，但必须通过 Release 标题、产物名称与平台文档如实披露。
+本文记录 Desktop beta.2 的发布门禁；2026-08-15 完成的 beta.1 实体机验收作为本版本基线，本次仍须复核精确 main SHA 的 beta.2 候选。外发 `desktop-v0.1.0-beta.2` 前必须取得 `release_eligible:true` 候选并完成资产核验。代码签名、公证、Authenticode 与自动更新不属于这次明确标记为未签名 beta 的阻塞项，但必须通过 Release 标题、产物名称与平台文档如实披露。
 
 验证环境（发布阻塞修复轮，分支 `fix/desktop-gui-p0-recovery`，base `f8b8234f`）：macOS 26.5.2 / Apple Silicon（arm64）实体机；Python 3.14.6 独立 venv（pytest 9.1.1）；Node 25.9.0 / npm 11.12.1（`npm ci`）；rustc 1.93.1。该轮 CLI 验证全部使用隔离 `HOME` / `CLAUDE_KEYSMITH_HOME` / `CLAUDE_KEYSMITH_SHELL_RC`，版本切换专项只运行临时 npm prefix 中的 `claude --version`；用户安装路径的最终升级验收另见第二节。
 
@@ -98,8 +98,8 @@
 ## 三、发布政策与边界声明
 
 - 本分支仅产出源码、文档与候选构建链；发行打包只用 `npm run bundle`。
-- 候选证据（sidecar / `BUILD_INFO.json` / 全量 `SHA256SUMS`）保留在本地候选目录与 CI artifact；Desktop Pre-release 仅上传 DMG、NSIS 与面向用户的 `SHA256SUMS`，CLI sidecar archive 不作为 `v7` 公共产物。
+- 候选证据（sidecar / `BUILD_INFO.json` / 全量 `SHA256SUMS`）保留在本地候选目录与 CI artifact；Desktop Pre-release 仅上传 DMG、NSIS 与面向用户的 `SHA256SUMS`，CLI sidecar archive 不作为公开资产。
 - **本次 beta 已接受限制（不单独阻塞 beta）**：无开发者代码签名、无 macOS notarization、无 Windows Authenticode、无自动更新、无 Linux GUI。Release 标题与产物名称必须明确标记 `unsigned beta`，附 SHA-256；人工安装说明保留在 [`platform-support.md`](platform-support.md)，tag 与 `BUILD_INFO.json` 共同绑定 source commit。不得暗示系统信任链或自动更新能力已经具备。
 - **真正的 beta 发布门禁**：实体机验收已完成；外发前必须取得两个目标平台的精确 main SHA 候选并复核元数据、安装器、sidecar、校验清单、版本、架构与签名状态，任何 tag 或 Release 仍需单独明确授权。
 - 若后续改为稳定版或默认面向普通用户分发，macOS Developer ID + notarization 与 Windows Authenticode 应升级为对应平台发布门禁；自动更新仍是独立产品能力，不在本 beta 承诺内。
-- 发布采用同批次双 Pre-release：`v7`（CLI）与 `desktop-v0.1.0-beta.1`（GUI beta）指向同一最终 main commit；完成精确候选复核并取得明确授权后方可创建 tag 与 GitHub Release。
+- `desktop-v0.1.0-beta.2` 为独立 Desktop Pre-release；完成精确候选复核并取得明确授权后方可创建 tag 与 GitHub Release。

--- a/docs/desktop-gui.md
+++ b/docs/desktop-gui.md
@@ -1,7 +1,7 @@
 <!-- markdownlint-disable MD013 -->
 # 桌面客户端（GUI）架构与操作手册
 
-`gui/` 是 `claude-keysmith` 的桌面客户端，版本 `0.1.0-beta.1`，构建 channel `beta`，是**未签名 Pre-release**，不是稳定版。它是 CLI（`claude-instruct.py`）的可视化封装：所有文件写入都由 CLI 完成，GUI 自身不直接修改任何目标文件。
+`gui/` 是 `claude-keysmith` 的桌面客户端，版本 `0.1.0-beta.2`，构建 channel `beta`，是**未签名 Pre-release**，不是稳定版。它是 CLI（`claude-instruct.py`）的可视化封装：所有文件写入都由 CLI 完成，GUI 自身不直接修改任何目标文件。
 
 - 技术栈：Tauri 2 + React 19 + Vite 6 + Tailwind CSS 4 + Radix UI + Motion；`react-i18next`（zh-CN / en）；`sonner` toast。
 - CLI 载体：PyInstaller onefile sidecar（`claude-keysmith-cli`），与 GUI 同源构建。

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -1,7 +1,7 @@
 <!-- markdownlint-disable MD013 -->
 # 平台支持矩阵
 
-桌面客户端 `claude-keysmith` GUI `0.1.0-beta.1`（channel `beta`，未签名 Pre-release）的目标产物与验收状态。配置存在 ≠ 验收通过；Windows 产物不能在 macOS worktree 本机构建或运行，原生构建与自动化安装链由 GitHub 托管 Windows x64 runner 验证，两平台用户可见行为由实体机验收补齐。
+桌面客户端 `claude-keysmith` GUI `0.1.0-beta.2`（channel `beta`，未签名 Pre-release）的目标产物与验收状态。配置存在 ≠ 验收通过；Windows 产物不能在 macOS worktree 本机构建或运行，原生构建与自动化安装链由 GitHub 托管 Windows x64 runner 验证，两平台用户可见行为由实体机验收补齐。
 
 ## 产物矩阵
 
@@ -13,7 +13,7 @@
 
 两种受支持平台都只用 `cd gui && npm run bundle` 生成发行产物。该入口先原生构建 sidecar，再加载打包 overlay 启用 bundle 和 `externalBin`；裸 Tauri 构建不是发行打包入口。
 
-## `desktop-v0.1.0-beta.1` 的发布门禁
+## `desktop-v0.1.0-beta.2` 的发布门禁
 
 实体机门禁已由维护者于 2026-08-15 确认全部通过；外发前继续强制核对候选可追溯性与发布授权：
 
@@ -26,7 +26,7 @@
 
 ## 本次未签名 beta 已接受的限制
 
-以下能力尚未提供，但在 Release 标题和产物名称明确标记 `unsigned beta`、提供 SHA-256，并在本文保留人工安装说明的前提下，**不单独阻塞 `desktop-v0.1.0-beta.1`**：
+以下能力尚未提供，但在 Release 标题和产物名称明确标记 `unsigned beta`、提供 SHA-256，并在本文保留人工安装说明的前提下，**不单独阻塞 `desktop-v0.1.0-beta.2`**：
 
 1. **代码签名 / notarization / Authenticode**：均未配置发行身份。macOS 候选使用完整 ad-hoc 签名（无 hardened runtime），`codesign --verify --deep --strict` 通过但 `spctl` 拒绝；Windows 安装器、GUI、sidecar 与 uninstaller 均为 `NotSigned`，两平台人工放行路径已完成实体机验收。
 2. **自动更新**：未实现，无 updater 配置；本 beta 仅支持用户手动下载、校验并安装后续版本。
@@ -39,7 +39,7 @@
 下载后先使用 Release 附带的 `SHA256SUMS` 校验安装包，再按平台安装：
 
 - **macOS Apple Silicon**：打开 `.dmg` 并将应用拖入 Applications。首次启动若被 Gatekeeper 拦截，在 Finder 中按住 Control 点击应用并选择“打开”；仍被阻止时，前往“系统设置 → 隐私与安全性”，确认目标应用后选择“仍要打开”。系统版本不同可能使用近似文案。
-- **Windows x64**：先用 `Get-FileHash .\claude-keysmith-desktop-0.1.0-beta.1-windows-x64-unsigned-setup.exe -Algorithm SHA256` 校验安装器，再运行该文件。若 SmartScreen 拦截，核对文件名与 SHA-256 后选择“更多信息 → 仍要运行”。无 WebView2 的机器会由安装器静默下载 bootstrapper，因此安装阶段需要可访问 Microsoft 下载服务的网络。
+- **Windows x64**：先用 `Get-FileHash .\claude-keysmith-desktop-0.1.0-beta.2-windows-x64-unsigned-setup.exe -Algorithm SHA256` 校验安装器，再运行该文件。若 SmartScreen 拦截，核对文件名与 SHA-256 后选择“更多信息 → 仍要运行”。无 WebView2 的机器会由安装器静默下载 bootstrapper，因此安装阶段需要可访问 Microsoft 下载服务的网络。
 
 ## CLI 平台支持（背景，不属于 GUI 产物）
 

--- a/docs/release-notes-drafts.md
+++ b/docs/release-notes-drafts.md
@@ -1,35 +1,15 @@
 <!-- markdownlint-disable MD013 -->
-# Release Notes 草稿（双 Pre-release）
+# Release Notes 草稿
 
-发布方式：`v7` 与 `desktop-v0.1.0-beta.1` 同批标记为 **Pre-release**，两者指向同一个最终 main commit。
+## Desktop 0.1.0-beta.2：未签名 Beta
 
-## v7
+- 深色主题对齐 Codex tech blue。
+- 修复 Windows 安装/卸载时 WebView2 子进程残留问题。
+- 支持 macOS Apple Silicon 和 Windows x64；未签名、无自动更新。
+- 下载后请使用 `SHA256SUMS` 校验安装包。
 
-### v7：事务恢复与运行时稳定性（预发布）
+公开资产：
 
-claude-keysmith v7 预发布版，集中验证自动化契约、写入安全和 Claude Code 更新后的运行时稳定性。
-
-升级 runtime wrapper：
-
-```bash
-python3 claude-instruct.py install --scope user --runtime
-python3 claude-instruct.py install --scope user --runtime --yes
-```
-
-## desktop-v0.1.0-beta.1
-
-### Desktop 0.1.0-beta.1：未签名桌面客户端 beta
-
-首个 claude-keysmith 桌面客户端 beta，内嵌与 v7 同源构建的 CLI。
-
-- 提供 Dashboard、三步 Deploy、Manage（uninstall / restore / recover / repair）和中英文 Settings。
-- 所有写操作都经过 preview → confirm → execute，并具备全局写互斥、关闭等待、超时杀进程树和事务恢复。
-- 支持 macOS Apple Silicon 与 Windows x64；无 Linux GUI、无自动更新。
-
-产物：
-
-- `claude-keysmith-desktop-0.1.0-beta.1-macos-arm64-unsigned.dmg`
-- `claude-keysmith-desktop-0.1.0-beta.1-windows-x64-unsigned-setup.exe`
+- `claude-keysmith-desktop-0.1.0-beta.2-macos-arm64-unsigned.dmg`
+- `claude-keysmith-desktop-0.1.0-beta.2-windows-x64-unsigned-setup.exe`
 - `SHA256SUMS`
-
-最终 SHA-256 以精确 main 候选生成后的校验清单为准。

--- a/gui/SPEC.md
+++ b/gui/SPEC.md
@@ -1,7 +1,7 @@
 <!-- markdownlint-disable MD013 -->
 # claude-keysmith GUI — 工程规范（SPEC）
 
-版本 `0.1.0-beta.1`，channel `beta`，未签名 Pre-release。本规范描述桌面客户端的架构与不可违背的约束；所有条目都能在代码中找到对应实现。发布状态与验收见 [`../docs/platform-support.md`](../docs/platform-support.md) 与 [`../docs/beta-acceptance.md`](../docs/beta-acceptance.md)。
+版本 `0.1.0-beta.2`，channel `beta`，未签名 Pre-release。本规范描述桌面客户端的架构与不可违背的约束；所有条目都能在代码中找到对应实现。发布状态与验收见 [`../docs/platform-support.md`](../docs/platform-support.md) 与 [`../docs/beta-acceptance.md`](../docs/beta-acceptance.md)。
 
 ## 1. 定位与边界
 

--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-keysmith-gui",
-  "version": "0.1.0-beta.1",
+  "version": "0.1.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-keysmith-gui",
-      "version": "0.1.0-beta.1",
+      "version": "0.1.0-beta.2",
       "dependencies": {
         "@fontsource/geist-mono": "^5.3.0",
         "@fontsource/geist-sans": "^5.3.0",

--- a/gui/package.json
+++ b/gui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-keysmith-gui",
   "private": true,
-  "version": "0.1.0-beta.1",
+  "version": "0.1.0-beta.2",
   "type": "module",
   "scripts": {
     "dev": "node scripts/generate-build-info.mjs && vite",

--- a/gui/src-tauri/Cargo.lock
+++ b/gui/src-tauri/Cargo.lock
@@ -467,7 +467,7 @@ dependencies = [
 
 [[package]]
 name = "claude-keysmith-gui"
-version = "0.1.0-beta.1"
+version = "0.1.0-beta.2"
 dependencies = [
  "libc",
  "serde",

--- a/gui/src-tauri/Cargo.toml
+++ b/gui/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-keysmith-gui"
-version = "0.1.0-beta.1"
+version = "0.1.0-beta.2"
 description = "Visual client for claude-keysmith"
 edition = "2021"
 

--- a/gui/src/lib/buildInfo.test.js
+++ b/gui/src/lib/buildInfo.test.js
@@ -6,12 +6,12 @@ const VALID = "0123456789abcdef0123456789abcdef01234567";
 describe("normalizeBuildInfo", () => {
   it("keeps a valid injected build", () => {
     const info = normalizeBuildInfo({
-      guiVersion: "0.1.0-beta.1",
+      guiVersion: "0.1.0-beta.2",
       channel: "beta",
       sourceCommit: VALID,
       sidecarCommit: VALID,
     });
-    expect(info.guiVersion).toBe("0.1.0-beta.1");
+    expect(info.guiVersion).toBe("0.1.0-beta.2");
     expect(info.channel).toBe("beta");
     expect(info.sourceCommit).toBe(VALID);
   });
@@ -37,7 +37,7 @@ describe("normalizeBuildInfo", () => {
 
 describe("generated buildInfo", () => {
   it("exposes the beta GUI version from package.json", () => {
-    expect(buildInfo.guiVersion).toBe("0.1.0-beta.1");
+    expect(buildInfo.guiVersion).toBe("0.1.0-beta.2");
     expect(buildInfo.channel).toBe("beta");
   });
 });


### PR DESCRIPTION
## 变更
- 统一 Desktop GUI/package/Cargo 版本到 0.1.0-beta.2。
- 更新 beta.2 文档、安装链接和精简发布说明。
- 保留 beta.1 历史 Release 不变。

## 本地验证
- CLI pytest: 135 passed
- GUI Vitest: 113 passed
- Rust fmt/check/test: 7 passed
- Vite production build: passed

合并后将从精确 main SHA 重新运行 GUI release candidate；本 PR 不创建 tag 或 Release。