### PR TITLE
fix(windows): GUI 无 PSModulePath 时回退 Documents profile

### DIFF
--- a/.github/workflows/gui-release-candidate.yml
+++ b/.github/workflows/gui-release-candidate.yml
@@ -150,8 +150,11 @@ jobs:
           $installer = $installers[0]
 
           $guiVersion = (Get-Content gui/package.json -Raw | ConvertFrom-Json).version
+          $cliTag = (Select-String -Path claude-instruct.py -Pattern '^VERSION = "([^"]+)"').Matches[0].Groups[1].Value
+          if (-not $cliTag) { throw 'VERSION not found in claude-instruct.py' }
+          $expectedCliVersion = "claude-keysmith $cliTag"
           $cliVersion = (& $sidecar --version | Out-String).Trim()
-          if ($LASTEXITCODE -ne 0 -or $cliVersion -ne 'claude-keysmith v7.1') { throw "sidecar --version smoke failed: $cliVersion" }
+          if ($LASTEXITCODE -ne 0 -or $cliVersion -ne $expectedCliVersion) { throw "sidecar --version smoke failed: $cliVersion (expected $expectedCliVersion)" }
 
           $installerSignature = (Get-AuthenticodeSignature -LiteralPath $installer.FullName).Status.ToString()
           if ($installerSignature -ne 'NotSigned') { throw "candidate must remain unsigned; installer signature is $installerSignature" }
@@ -171,8 +174,8 @@ jobs:
           }
 
           $installedCliVersion = (& $installedSidecar --version | Out-String).Trim()
-          if ($LASTEXITCODE -ne 0 -or $installedCliVersion -ne 'claude-keysmith v7.1') {
-            throw "installed sidecar smoke failed: $installedCliVersion"
+          if ($LASTEXITCODE -ne 0 -or $installedCliVersion -ne $expectedCliVersion) {
+            throw "installed sidecar smoke failed: $installedCliVersion (expected $expectedCliVersion)"
           }
           $sourceSidecarHash = (Get-FileHash -LiteralPath $sidecar -Algorithm SHA256).Hash.ToLowerInvariant()
           $installedSidecarHash = (Get-FileHash -LiteralPath $installedSidecar -Algorithm SHA256).Hash.ToLowerInvariant()
@@ -357,7 +360,7 @@ jobs:
 
           $installerAsset = Join-Path $stage "claude-keysmith-desktop-$guiVersion-windows-x64-unsigned-setup.exe"
           Copy-Item -LiteralPath $installer.FullName -Destination $installerAsset
-          $sidecarArchive = Join-Path $stage 'claude-keysmith-cli-v7.1-windows-x64-unsigned.zip'
+          $sidecarArchive = Join-Path $stage "claude-keysmith-cli-$cliTag-windows-x64-unsigned.zip"
           Compress-Archive -LiteralPath $sidecar -DestinationPath $sidecarArchive
 
           $files = @(Get-ChildItem -LiteralPath $stage -File | Sort-Object Name)
@@ -493,8 +496,11 @@ jobs:
           hdiutil verify "$dmg"
 
           gui_version="$(node -p "require('./gui/package.json').version")"
+          cli_tag="$(sed -n 's/^VERSION = "\(.*\)"/\1/p' claude-instruct.py | head -n 1)"
+          [ -n "$cli_tag" ] || { echo "VERSION not found in claude-instruct.py" >&2; exit 1; }
+          expected_cli_version="claude-keysmith $cli_tag"
           cli_version="$("$sidecar" --version)"
-          [ "$cli_version" = "claude-keysmith v7.1" ] || { echo "sidecar version mismatch: $cli_version" >&2; exit 1; }
+          [ "$cli_version" = "$expected_cli_version" ] || { echo "sidecar version mismatch: $cli_version (expected $expected_cli_version)" >&2; exit 1; }
           codesign --verify --strict --verbose=4 "$sidecar"
           source_signature_info="$(codesign -dvvv "$sidecar" 2>&1)"
           printf '%s\n' "$source_signature_info" | grep -q '^Signature=adhoc$'
@@ -528,7 +534,7 @@ jobs:
           [ "$gui_arch" = "arm64" ] || { echo "GUI architecture mismatch: $gui_arch" >&2; exit 1; }
           [ "$embedded_arch" = "arm64" ] || { echo "embedded sidecar architecture mismatch: $embedded_arch" >&2; exit 1; }
           embedded_cli_version="$("$embedded_sidecar" --version)"
-          [ "$embedded_cli_version" = "claude-keysmith v7.1" ] || { echo "embedded sidecar version mismatch: $embedded_cli_version" >&2; exit 1; }
+          [ "$embedded_cli_version" = "$expected_cli_version" ] || { echo "embedded sidecar version mismatch: $embedded_cli_version (expected $expected_cli_version)" >&2; exit 1; }
           codesign --verify --strict --verbose=4 "$embedded_sidecar"
           embedded_signature_info="$(codesign -dvvv "$embedded_sidecar" 2>&1)"
           printf '%s\n' "$embedded_signature_info" | grep -q '^Signature=adhoc$'
@@ -567,13 +573,14 @@ jobs:
 
           dmg_asset="$stage/claude-keysmith-desktop-${gui_version}-macos-arm64-unsigned.dmg"
           cp "$dmg" "$dmg_asset"
-          sidecar_archive="$stage/claude-keysmith-cli-v7.1-macos-arm64-adhoc.tar.gz"
+          sidecar_archive="$stage/claude-keysmith-cli-${cli_tag}-macos-arm64-adhoc.tar.gz"
           tar -czf "$sidecar_archive" -C "$(dirname "$sidecar")" "$(basename "$sidecar")"
           tar -tzf "$sidecar_archive" | grep -qx 'claude-keysmith-cli-aarch64-apple-darwin'
 
           export STAGE_DIR="$stage"
           export GUI_VERSION="$gui_version"
           export CLI_VERSION="$cli_version"
+          export CLI_TAG="$cli_tag"
           export SOURCE_COMMIT="$source_commit"
           export GUI_ARCH="$gui_arch"
           export SOURCE_SIDECAR_SHA256="$source_sidecar_sha256"
@@ -592,7 +599,7 @@ jobs:
           artifact_paths = sorted(
               [
                   next(stage.glob("*.dmg")),
-                  stage / "claude-keysmith-cli-v7.1-macos-arm64-adhoc.tar.gz",
+                  stage / f"claude-keysmith-cli-{os.environ['CLI_TAG']}-macos-arm64-adhoc.tar.gz",
               ],
               key=lambda path: path.name,
           )

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Windows Desktop / sidecar 在没有用户级 `PSModulePath`（资源管理器启动的 GUI 进程常见）时，不再把 runtime 探测直接失败关闭。改为：仍优先使用 `PSModulePath` 里第一个可识别的用户 Modules 条目；没有时回退到用户 Documents 下已存在的 PowerShell profile，否则写入 Win10 默认的 `Documents\\WindowsPowerShell\\Microsoft.PowerShell_profile.ps1`。`CLAUDE_KEYSMITH_SHELL_RC` 仍然覆盖。
+- `status --json` / `doctor --json` 在 runtime 探测或 project-dir 校验失败时仍输出契约 JSON，GUI 不再把 stdout 里的 `[错误]` 文本显示成「状态加载失败 / CLI 未输出稳定 JSON」。
+
 ## v7.2 (2026-09-10)
 
 - Bundled project-rules rewritten as a short lab/CTF/pentest project face; creative delivery stays in append only. Authorization-term recast removed after Opus 5 read it as a refusal-override.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Windows Desktop / sidecar 在没有用户级 `PSModulePath`（资源管理器启动的 GUI 进程常见）时，不再把 runtime 探测直接失败关闭。改为：仍优先使用 `PSModulePath` 里第一个可识别的用户 Modules 条目；没有时回退到用户 Documents 下已存在的 PowerShell profile，否则写入 Win10 默认的 `Documents\\WindowsPowerShell\\Microsoft.PowerShell_profile.ps1`。Known Folder / 注册表只在 *home* 就是当前 Windows 用户配置目录时启用，避免 `CLAUDE_KEYSMITH_HOME` 或测试夹具写到 runner 自己的 Documents。`CLAUDE_KEYSMITH_SHELL_RC` 仍然覆盖。
 - `status --json` / `doctor --json` 在 runtime 探测或 project-dir 校验失败时仍输出契约 JSON，GUI 不再把 stdout 里的 `[错误]` 文本显示成「状态加载失败 / CLI 未输出稳定 JSON」。
+- `gui-release-candidate` 的 sidecar `--version` 断言改为读取 `claude-instruct.py` 的 `VERSION`，不再写死 `v7.1`。
 
 ## v7.2 (2026-09-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Windows Desktop / sidecar 在没有用户级 `PSModulePath`（资源管理器启动的 GUI 进程常见）时，不再把 runtime 探测直接失败关闭。改为：仍优先使用 `PSModulePath` 里第一个可识别的用户 Modules 条目；没有时回退到用户 Documents 下已存在的 PowerShell profile，否则写入 Win10 默认的 `Documents\\WindowsPowerShell\\Microsoft.PowerShell_profile.ps1`。`CLAUDE_KEYSMITH_SHELL_RC` 仍然覆盖。
+- Windows Desktop / sidecar 在没有用户级 `PSModulePath`（资源管理器启动的 GUI 进程常见）时，不再把 runtime 探测直接失败关闭。改为：仍优先使用 `PSModulePath` 里第一个可识别的用户 Modules 条目；没有时回退到用户 Documents 下已存在的 PowerShell profile，否则写入 Win10 默认的 `Documents\\WindowsPowerShell\\Microsoft.PowerShell_profile.ps1`。Known Folder / 注册表只在 *home* 就是当前 Windows 用户配置目录时启用，避免 `CLAUDE_KEYSMITH_HOME` 或测试夹具写到 runner 自己的 Documents。`CLAUDE_KEYSMITH_SHELL_RC` 仍然覆盖。
 - `status --json` / `doctor --json` 在 runtime 探测或 project-dir 校验失败时仍输出契约 JSON，GUI 不再把 stdout 里的 `[错误]` 文本显示成「状态加载失败 / CLI 未输出稳定 JSON」。
 
 ## v7.2 (2026-09-10)

--- a/claude-instruct.py
+++ b/claude-instruct.py
@@ -385,8 +385,47 @@ def _windows_documents_from_registry() -> Optional[Path]:
     return Path(expanded) if expanded else None
 
 
+def _path_identity(path: Path) -> str:
+    return os.path.normcase(os.path.abspath(str(Path(path).expanduser())))
+
+
+def _home_is_windows_user_profile(home: Path) -> bool:
+    """True when *home* is the real Windows user profile, not a test/override HOME.
+
+    Known Folder / registry Documents must not leak into an isolated
+    CLAUDE_KEYSMITH_HOME or $HOME fixture. Path.home() on Windows reads
+    USERPROFILE and ignores Unix $HOME, which is the GUI sidecar case.
+    """
+    if os.name != "nt":
+        return False
+    try:
+        home_key = _path_identity(home)
+    except (OSError, ValueError, TypeError):
+        return False
+    candidates = []
+    userprofile = _env_case_insensitive("USERPROFILE")
+    if userprofile:
+        candidates.append(userprofile)
+    try:
+        candidates.append(str(Path.home()))
+    except (OSError, RuntimeError):
+        pass
+    for candidate in candidates:
+        try:
+            if _path_identity(Path(candidate)) == home_key:
+                return True
+        except (OSError, ValueError, TypeError):
+            continue
+    return False
+
+
 def iter_user_documents_dirs(home: Path) -> List[Path]:
-    """Candidate Documents directories, known-folder first, then HOME fallbacks."""
+    """Candidate Documents directories for the given keysmith home.
+
+    Machine Known Folder / shell-folder registry / USERPROFILE\\Documents are
+    only consulted when *home* is the real Windows user profile. Isolated test
+    homes and CLAUDE_KEYSMITH_HOME overrides stay inside that home.
+    """
     ordered: List[Path] = []
     seen = set()
 
@@ -394,7 +433,7 @@ def iter_user_documents_dirs(home: Path) -> List[Path]:
         if path is None:
             return
         try:
-            key = os.path.normcase(os.path.abspath(str(Path(path).expanduser())))
+            key = _path_identity(path)
         except (OSError, ValueError, TypeError):
             return
         if key in seen:
@@ -402,12 +441,13 @@ def iter_user_documents_dirs(home: Path) -> List[Path]:
         seen.add(key)
         ordered.append(Path(key))
 
-    add(_windows_documents_from_known_folder())
-    add(_windows_documents_from_registry())
-    userprofile = _env_case_insensitive("USERPROFILE")
-    if userprofile:
-        for name in _DOCUMENTS_DIR_NAMES:
-            add(Path(userprofile) / name)
+    if _home_is_windows_user_profile(home):
+        add(_windows_documents_from_known_folder())
+        add(_windows_documents_from_registry())
+        userprofile = _env_case_insensitive("USERPROFILE")
+        if userprofile:
+            for name in _DOCUMENTS_DIR_NAMES:
+                add(Path(userprofile) / name)
     for name in _DOCUMENTS_DIR_NAMES:
         add(home / name)
     if not ordered:

--- a/claude-instruct.py
+++ b/claude-instruct.py
@@ -304,49 +304,6 @@ def runtime_shell_kind() -> str:
     return "powershell" if os.name == "nt" else "zsh"
 
 
-def powershell_profile_path(home: Path) -> Path:
-    """Locate PowerShell profile for PS5 (WindowsPowerShell) or PS7 (PowerShell).
-
-    Override with $CLAUDE_KEYSMITH_SHELL_RC.
-    """
-    configured = os.environ.get("CLAUDE_KEYSMITH_SHELL_RC")
-    if configured:
-        return Path(configured).expanduser().resolve()
-    module_path = os.environ.get("PSModulePath", "")
-    if ";" in module_path:
-        entries = module_path.split(";")
-    elif os.pathsep == ":" and not re.match(r"^[A-Za-z]:[\\/]", module_path):
-        entries = module_path.split(os.pathsep)
-    else:
-        entries = [module_path]
-    for entry in (item.strip().strip('"') for item in entries):
-        if not entry:
-            continue
-        module_dir = Path(entry).expanduser()
-        # Fresh Windows installs can advertise the user module path before the
-        # directory has been created, so classify the path by structure.
-        if module_dir.name.lower() != "modules":
-            continue
-        shell_dir = module_dir.parent
-        if shell_dir.name.lower() not in {"windowspowershell", "powershell"}:
-            continue
-        lowered_parts = {part.lower() for part in module_dir.parts}
-        if lowered_parts.intersection({"program files", "program files (x86)", "system32"}):
-            continue
-        try:
-            module_dir.resolve().relative_to(home.expanduser().resolve())
-            user_level = True
-        except ValueError:
-            user_level = "documents" in lowered_parts
-        if not user_level:
-            continue
-        return shell_dir / "Microsoft.PowerShell_profile.ps1"
-    raise ValueError(
-        "无法从 PSModulePath 判断 PowerShell 5.1/7 profile；"
-        "请设置 CLAUDE_KEYSMITH_SHELL_RC 为目标 profile 的完整路径"
-    )
-
-
 def _env_case_insensitive(name: str) -> Optional[str]:
     """Read an environment variable with Windows-compatible case matching."""
     direct = os.environ.get(name)
@@ -357,6 +314,181 @@ def _env_case_insensitive(name: str) -> Optional[str]:
         if key.lower() == lowered:
             return value
     return None
+
+
+_POWERSHELL_PROFILE_NAME = "Microsoft.PowerShell_profile.ps1"
+_POWERSHELL_PROFILE_DIRS = ("WindowsPowerShell", "PowerShell")
+_DOCUMENTS_DIR_NAMES = ("Documents", "文档")
+_SYSTEM_MODULE_MARKERS = {"program files", "program files (x86)", "system32"}
+
+
+def _windows_documents_from_known_folder() -> Optional[Path]:
+    """Resolve the current user's Documents folder via SHGetKnownFolderPath."""
+    if os.name != "nt":
+        return None
+    try:
+        import ctypes
+        import uuid as uuid_mod
+    except ImportError:
+        return None
+
+    class GUID(ctypes.Structure):
+        _fields_ = [
+            ("Data1", ctypes.c_uint32),
+            ("Data2", ctypes.c_uint16),
+            ("Data3", ctypes.c_uint16),
+            ("Data4", ctypes.c_ubyte * 8),
+        ]
+
+    folder_id = uuid_mod.UUID("{FDD39AD0-238F-46AF-ADB4-6C85480369C7}")
+    guid = GUID(
+        folder_id.time_low,
+        folder_id.time_mid,
+        folder_id.time_hi_version,
+        (ctypes.c_ubyte * 8).from_buffer_copy(folder_id.bytes[8:]),
+    )
+    path_ptr = ctypes.c_wchar_p()
+    try:
+        hr = ctypes.windll.shell32.SHGetKnownFolderPath(
+            ctypes.byref(guid), 0, None, ctypes.byref(path_ptr)
+        )
+    except (AttributeError, OSError, ValueError, TypeError):
+        return None
+    if hr != 0 or not path_ptr.value:
+        return None
+    try:
+        return Path(path_ptr.value)
+    finally:
+        try:
+            ctypes.windll.ole32.CoTaskMemFree(path_ptr)
+        except (AttributeError, OSError, ValueError, TypeError):
+            pass
+
+
+def _windows_documents_from_registry() -> Optional[Path]:
+    """Resolve Documents from the user shell-folder registry (OneDrive-aware)."""
+    if os.name != "nt":
+        return None
+    try:
+        import winreg
+    except ImportError:
+        return None
+    try:
+        with winreg.OpenKey(
+            winreg.HKEY_CURRENT_USER,
+            r"Software\Microsoft\Windows\CurrentVersion\Explorer\User Shell Folders",
+        ) as key:
+            value, _ = winreg.QueryValueEx(key, "Personal")
+    except OSError:
+        return None
+    expanded = os.path.expandvars(str(value)).strip().strip('"')
+    return Path(expanded) if expanded else None
+
+
+def iter_user_documents_dirs(home: Path) -> List[Path]:
+    """Candidate Documents directories, known-folder first, then HOME fallbacks."""
+    ordered: List[Path] = []
+    seen = set()
+
+    def add(path: Optional[Path]) -> None:
+        if path is None:
+            return
+        try:
+            key = os.path.normcase(os.path.abspath(str(Path(path).expanduser())))
+        except (OSError, ValueError, TypeError):
+            return
+        if key in seen:
+            return
+        seen.add(key)
+        ordered.append(Path(key))
+
+    add(_windows_documents_from_known_folder())
+    add(_windows_documents_from_registry())
+    userprofile = _env_case_insensitive("USERPROFILE")
+    if userprofile:
+        for name in _DOCUMENTS_DIR_NAMES:
+            add(Path(userprofile) / name)
+    for name in _DOCUMENTS_DIR_NAMES:
+        add(home / name)
+    if not ordered:
+        add(home / "Documents")
+    return ordered
+
+
+def _split_ps_module_path(module_path: str) -> List[str]:
+    if not module_path.strip():
+        return []
+    if ";" in module_path:
+        entries = module_path.split(";")
+    elif os.pathsep == ":" and not re.match(r"^[A-Za-z]:[\\/]", module_path):
+        entries = module_path.split(os.pathsep)
+    else:
+        entries = [module_path]
+    cleaned: List[str] = []
+    for item in entries:
+        entry = item.strip().strip('"')
+        if entry:
+            cleaned.append(entry)
+    return cleaned
+
+
+def _profile_from_module_dir(module_dir: Path, home: Path) -> Optional[Path]:
+    """Return the CurrentUserCurrentHost profile for a user-level Modules path."""
+    if module_dir.name.lower() != "modules":
+        return None
+    shell_dir = module_dir.parent
+    if shell_dir.name.lower() not in {"windowspowershell", "powershell"}:
+        return None
+    lowered_parts = {part.lower() for part in module_dir.parts}
+    if lowered_parts.intersection(_SYSTEM_MODULE_MARKERS):
+        return None
+    try:
+        module_dir.expanduser().resolve().relative_to(home.expanduser().resolve())
+        user_level = True
+    except ValueError:
+        user_level = "documents" in lowered_parts or "文档" in module_dir.parts
+    if not user_level:
+        return None
+    return shell_dir / _POWERSHELL_PROFILE_NAME
+
+
+def _fallback_powershell_profile(home: Path) -> Path:
+    """Pick a user profile when PSModulePath has no recognizable user entry.
+
+    GUI / sidecar processes typically inherit no PowerShell engine environment,
+    so PSModulePath is empty or system-only. Prefer an already-created profile
+    file; otherwise target Windows PowerShell 5.1 under Documents, which is the
+    Win10 default host. $CLAUDE_KEYSMITH_SHELL_RC still overrides.
+    """
+    documents_dirs = iter_user_documents_dirs(home)
+    for docs in documents_dirs:
+        for shell_dir in _POWERSHELL_PROFILE_DIRS:
+            candidate = docs / shell_dir / _POWERSHELL_PROFILE_NAME
+            try:
+                if candidate.is_file():
+                    return candidate
+            except OSError:
+                continue
+    return documents_dirs[0] / "WindowsPowerShell" / _POWERSHELL_PROFILE_NAME
+
+
+def powershell_profile_path(home: Path) -> Path:
+    """Locate PowerShell profile for PS5 (WindowsPowerShell) or PS7 (PowerShell).
+
+    Override with $CLAUDE_KEYSMITH_SHELL_RC. Prefer the first user-level
+    PSModulePath entry when the current process actually has one (console
+    PowerShell / pwsh). When PSModulePath is missing or only system paths —
+    the Desktop sidecar case — fall back to the user Documents profile.
+    """
+    configured = os.environ.get("CLAUDE_KEYSMITH_SHELL_RC")
+    if configured:
+        return Path(configured).expanduser().resolve()
+    module_path = _env_case_insensitive("PSModulePath") or ""
+    for entry in _split_ps_module_path(module_path):
+        profile = _profile_from_module_dir(Path(entry).expanduser(), home)
+        if profile is not None:
+            return profile
+    return _fallback_powershell_profile(home)
 
 
 def _path_key(path: Path) -> str:
@@ -2428,6 +2560,40 @@ def command_install(args) -> int:
     return 0
 
 
+def _unavailable_runtime_status(exc: BaseException) -> Dict[str, Any]:
+    """Runtime block used when the probe itself fails closed.
+
+    status --json must still emit a document so the GUI can show the real
+    reason instead of "CLI 未输出稳定 JSON".
+    """
+    message = str(exc)
+    return {
+        "supported": True,
+        "error": message,
+        "shell_kind": runtime_shell_kind(),
+        "system_prompt_file": "",
+        "append_prompt_file": "",
+        "settings_file": "",
+        "shell_rc": "",
+        "system_prompt_exists": False,
+        "append_prompt_exists": False,
+        "settings_system_prompt_aligned": False,
+        "shell_wrapper_present": False,
+        "shell_wrapper_managed": False,
+        "upstream_candidates": [],
+        "upstream_path": None,
+        "upstream_exists": False,
+        "shell_wrapper_current": False,
+        "legacy_launcher_detected": False,
+        "legacy_launcher_paths": [],
+        "legacy_launcher_conflict": False,
+        "legacy_launcher_conflict_paths": [],
+        "upgrade_required": True,
+        "runtime_ready": False,
+        "note": message,
+    }
+
+
 def collect_runtime_status(paths: ScopePaths, md_filename: str, planned: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     """Structured runtime status for user scope.
 
@@ -2553,7 +2719,10 @@ def collect_status(scope: str, project_dir: Optional[str], name: str, runtime: b
         if paths.scope != "user":
             status["runtime"] = {"supported": False, "reason": "runtime status only for user scope"}
         else:
-            runtime_status = collect_runtime_status(paths, md_filename)
+            try:
+                runtime_status = collect_runtime_status(paths, md_filename)
+            except (FileNotFoundError, ValueError, UnicodeDecodeError, json.JSONDecodeError, OSError) as exc:
+                runtime_status = _unavailable_runtime_status(exc)
             status["runtime"] = runtime_status
             status["presence"].update(
                 {
@@ -2596,11 +2765,57 @@ def collect_status(scope: str, project_dir: Optional[str], name: str, runtime: b
     return status
 
 
+def _status_error_payload(args: Any, message: str) -> Dict[str, Any]:
+    """status --json fail-closed document. GUI treats ok:false as ContractError."""
+    return {
+        "schema": JSON_SCHEMA,
+        "operation": "status",
+        "ok": False,
+        "error": message,
+        "blockers": [message],
+        "scope": getattr(args, "scope", None),
+        "root": None,
+        "memory_file": None,
+        "instruction_file": None,
+        "import_target": None,
+        "memory_file_exists": False,
+        "instruction_file_exists": False,
+        "import_block_exists": False,
+        "installed": False,
+        "presence": {
+            "memory_file": False,
+            "instruction_file": False,
+            "import_block": False,
+        },
+        "alignment": {"import_block_present": False},
+        "source_identity": {
+            "kind": "missing",
+            "instruction_sha256": None,
+            "instruction_size_bytes": None,
+            "drift": None,
+        },
+        "recovery_state": {
+            "journals": [],
+            "journal_count": 0,
+            "atomic_temp_files": [],
+            "atomic_temp_count": 0,
+            "conflicts": [],
+            "lock_present": False,
+            "lock_live": False,
+            "recovery_required": False,
+            "must_recover_before_writes": False,
+        },
+    }
+
+
 def command_status(args) -> int:
     try:
         status = collect_status(args.scope, args.project_dir, args.name, runtime=bool(getattr(args, "runtime", False)))
-    except (FileNotFoundError, ValueError, UnicodeDecodeError, json.JSONDecodeError) as exc:
-        print(f"[错误] {exc}")
+    except (FileNotFoundError, ValueError, UnicodeDecodeError, json.JSONDecodeError, OSError) as exc:
+        if args.json:
+            print(json.dumps(_status_error_payload(args, str(exc)), ensure_ascii=False, indent=2))
+        else:
+            print(f"[错误] {exc}")
         return 1
 
     if args.json:
@@ -3306,8 +3521,23 @@ def command_runtime_doctor(args) -> int:
             "shell_rc": str(rt["shell_rc"]),
             "repair_actions": repair_actions,
         }
-    except (FileNotFoundError, ValueError, UnicodeDecodeError, json.JSONDecodeError) as exc:
-        print(f"[错误] {exc}")
+    except (FileNotFoundError, ValueError, UnicodeDecodeError, json.JSONDecodeError, OSError) as exc:
+        message = str(exc)
+        status = {
+            "installation_type": "unavailable",
+            "upstream_candidates": [],
+            "upstream_path": None,
+            "system_prompt_file": "",
+            "append_prompt_file": "",
+            "settings_file": "",
+            "shell_kind": runtime_shell_kind(),
+            "shell_rc": "",
+            "repair_actions": [message],
+        }
+        if args.json:
+            print(json.dumps(status, ensure_ascii=False, indent=2))
+        else:
+            print(f"[错误] {message}")
         return 1
 
     if args.json:

--- a/docs/json-contract.md
+++ b/docs/json-contract.md
@@ -12,7 +12,8 @@
   - `ok: false` ⇒ 调用方必须视为失败并停止后续动作，即使 exit code 为 0 的场景也不存在——非零 exit 与 `ok:false` 同时成立。
   - 未捕获异常同样以 `ok: false` + `error` 输出 JSON（不丢 Python traceback 给调用方）。
   - **参数校验失败**（如 `--max-tokens 0`）在传入 `--json` 时也输出契约 JSON 到 stdout（`ok: false`、`exit_status: 2`，`error` / `blockers` 为 argparse 的具体原因），argparse 的 usage 文本仍保留在 stderr 供人工阅读；进程退出码为 2。
-  - GUI 侧的 proceed 判定见 `gui/src/lib/parser.js` 的 `gateReport`：`exit_code !== 0`、`blockers` 非空、`ok === false` 任一成立即 blocked。
+  - **`status --json` / `doctor --json` 探测失败**同样输出 JSON，不向 stdout 打印 `[错误]` 文本。`status` 在 project-dir 不存在等校验失败时给出 `ok: false` 的 status 文档；user-scope `--runtime` 的 profile/runtime 探测失败则仍返回 status 骨架，并把原因放进 `runtime.error` / `runtime_readiness.runtime_ready: false`。`doctor` 保持固定 9 键，把原因放进 `repair_actions`。
+  - GUI 侧的 proceed 判定见 `gui/src/lib/parser.js` 的 `gateReport`：`exit_code !== 0`、`blockers` 非空、`ok === false` 任一成立即 blocked。`parseStatusReport` 对 `ok: false` 抛出带 `error` 原文的 `ContractError`。
 - **凭证脱敏**：契约与文本输出都不包含 API token、cookie、Base URL 或非目标的 `settings.json` 字段值。`settings.json` 仅以路径（`settings_file`）和布尔对齐状态（`settings_system_prompt_aligned`）出现；`doctor` 更是固定 9 个键，永不扩展出凭证字段。
 - **sha256 / size_bytes**：`backups[]`、`source`/`sources`、`status.source_identity` 中的指纹均为 SHA-256 十六进制 + 字节数，供调用方核验内容，不展示内容本身。
 
@@ -221,7 +222,7 @@ target 在 runtime 安装时扩展为包含 `system_prompt_file`、`append_promp
 | `recovery_state` | `journals`、`journal_count`、`atomic_temp_files`、`atomic_temp_count`、`conflicts`、`lock_present`、`lock_live`、`recovery_required`、`must_recover_before_writes` |
 | `runtime` | 完整 runtime 状态（仅 user scope `--runtime`；非 user scope 为 `{supported: false, reason: ...}`） |
 
-`recovery_state.journals[]` 条目：`{journal_path, journal_id, operation, state, started_at, pid}`。`runtime_ready` 只有在 prompt 文件完整、settings 对齐、wrapper 为当前 v7.2 模板、上游入口存在且无旧 launcher 冲突时才为 `true`。
+`recovery_state.journals[]` 条目：`{journal_path, journal_id, operation, state, started_at, pid}`。`runtime_ready` 只有在 prompt 文件完整、settings 对齐、wrapper 为当前 v7.2 模板、上游入口存在且无旧 launcher 冲突时才为 `true`。user-scope `--runtime` 的 profile 探测失败时 `runtime.error` 为原因字符串，`runtime_readiness.runtime_ready` 为 `false`，其余 presence / recovery 块仍可用。project-dir 不存在时整个 status 文档为 `ok: false`。
 
 示例（未安装，user scope + `--runtime`，截选）：
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -35,7 +35,13 @@
 
 在 macOS / Linux 上，wrapper 是 `claude()` shell 函数；在 Windows PowerShell 上，wrapper 是 profile 中的 `function global:claude`。自 v6 起正式支持 Windows PowerShell 5.1 与 PowerShell 7；CMD 和 Git Bash 不属于 managed wrapper 支持范围。
 
-Windows profile 解析从实际用户级 `PSModulePath` 的首个可识别条目派生：条目中的 `WindowsPowerShell/Modules` 对应 Windows PowerShell 5.1 profile，`PowerShell/Modules` 对应 PowerShell 7 profile，并保留该条目前缀，因此支持重定向后的 Documents 目录。全新环境中，即使 `PSModulePath` 已声明的用户 `Modules` 目录尚未创建，也会按路径结构识别；没有可识别条目时，安装会停止并要求通过 `CLAUDE_KEYSMITH_SHELL_RC` 指定目标 profile，不会回退猜测。
+Windows profile 解析顺序：
+
+1. `$CLAUDE_KEYSMITH_SHELL_RC` 显式覆盖。
+2. 实际用户级 `PSModulePath` 的首个可识别条目：`WindowsPowerShell/Modules` → Windows PowerShell 5.1，`PowerShell/Modules` → PowerShell 7，并保留该条目前缀（支持重定向后的 Documents）。全新环境中，即使该 `Modules` 目录尚未创建，也会按路径结构识别。
+3. 若当前进程没有用户级 `PSModulePath`（Desktop sidecar / 资源管理器启动的 GUI 常见：变量为空，或只剩 Program Files / System32），回退到用户 Documents 目录：优先已存在的 `Microsoft.PowerShell_profile.ps1`（先 WindowsPowerShell 5.1，再 PowerShell 7），否则目标为 Win10 默认的 `Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1`。Documents 本身按 Known Folder / 用户壳文件夹注册表 / `USERPROFILE\Documents` / `USERPROFILE\文档` / `$HOME\Documents` 解析，因此 OneDrive 重定向和中文「文档」目录可用。
+
+仍可用 `$CLAUDE_KEYSMITH_SHELL_RC` 指定 PS7 或其他非默认 profile。
 
 可选环境变量覆盖：
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -39,7 +39,7 @@ Windows profile 解析顺序：
 
 1. `$CLAUDE_KEYSMITH_SHELL_RC` 显式覆盖。
 2. 实际用户级 `PSModulePath` 的首个可识别条目：`WindowsPowerShell/Modules` → Windows PowerShell 5.1，`PowerShell/Modules` → PowerShell 7，并保留该条目前缀（支持重定向后的 Documents）。全新环境中，即使该 `Modules` 目录尚未创建，也会按路径结构识别。
-3. 若当前进程没有用户级 `PSModulePath`（Desktop sidecar / 资源管理器启动的 GUI 常见：变量为空，或只剩 Program Files / System32），回退到用户 Documents 目录：优先已存在的 `Microsoft.PowerShell_profile.ps1`（先 WindowsPowerShell 5.1，再 PowerShell 7），否则目标为 Win10 默认的 `Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1`。Documents 本身按 Known Folder / 用户壳文件夹注册表 / `USERPROFILE\Documents` / `USERPROFILE\文档` / `$HOME\Documents` 解析，因此 OneDrive 重定向和中文「文档」目录可用。
+3. 若当前进程没有用户级 `PSModulePath`（Desktop sidecar / 资源管理器启动的 GUI 常见：变量为空，或只剩 Program Files / System32），回退到用户 Documents 目录：优先已存在的 `Microsoft.PowerShell_profile.ps1`（先 WindowsPowerShell 5.1，再 PowerShell 7），否则目标为 Win10 默认的 `Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1`。当 *home* 就是当前 Windows 用户配置目录（`USERPROFILE` / `Path.home()`）时，Documents 按 Known Folder / 用户壳文件夹注册表解析，因此 OneDrive 重定向可用；`CLAUDE_KEYSMITH_HOME` 或测试夹具只使用该 home 下的 `Documents` / `文档`，不会写到机器上另一个用户的 profile。
 
 仍可用 `$CLAUDE_KEYSMITH_SHELL_RC` 指定 PS7 或其他非默认 profile。
 

--- a/gui/src/lib/parser.js
+++ b/gui/src/lib/parser.js
@@ -230,6 +230,12 @@ export function mapRecoveryState(recovery) {
  */
 export function parseStatusReport(output) {
   const doc = parseContract(output);
+  if (doc.ok === false) {
+    throw new ContractError(
+      typeof doc.error === "string" && doc.error ? doc.error : "status failed",
+      output,
+    );
+  }
   const model = {
     scope: typeof doc.scope === "string" ? doc.scope : "user",
     root: typeof doc.root === "string" ? doc.root : null,

--- a/gui/src/lib/parser.test.js
+++ b/gui/src/lib/parser.test.js
@@ -341,6 +341,16 @@ describe("parseStatusReport / deriveHealth", () => {
     expect(model.runtimeReadiness).toBeNull();
     expect(model.health).toBe("healthy");
   });
+
+  it("surfaces status ok:false as the real error instead of missing JSON", () => {
+    expect(() => parseStatusReport(output({
+      schema: SCHEMA,
+      operation: "status",
+      ok: false,
+      error: "project directory 不存在或不是目录: /missing",
+      blockers: ["project directory 不存在或不是目录: /missing"],
+    }, { exitCode: 1 }))).toThrow(/project directory/);
+  });
 });
 
 describe("parseDoctorReport", () => {

--- a/tests/test_claude_instruct.py
+++ b/tests/test_claude_instruct.py
@@ -650,6 +650,93 @@ def test_windows_style_runtime_install_uses_powershell_profile(tmp_path):
     assert "# existing powershell profile" in profile_after
 
 
+def test_gui_like_runtime_preview_does_not_require_psmodulepath(tmp_path):
+    home = tmp_path / "home"
+    extra_env = {
+        "CLAUDE_KEYSMITH_SHELL": "powershell",
+        "PATH": str(home / "empty-path"),
+        "PSModulePath": "",
+    }
+    result = run_cli(
+        ["install", "--scope", "user", "--runtime", "--json"],
+        home=home,
+        extra_env=extra_env,
+        check=False,
+    )
+    payload = json.loads(result.stdout)
+    blockers = " ".join(payload.get("blockers") or [])
+    error = payload.get("error") or ""
+    assert "PSModulePath" not in blockers
+    assert "PSModulePath" not in error
+    assert "CLAUDE_KEYSMITH_SHELL_RC" not in blockers
+    expected_profile = home / "Documents" / "WindowsPowerShell" / "Microsoft.PowerShell_profile.ps1"
+    assert Path(payload["target"]["shell_rc"]) == expected_profile
+
+
+def test_status_json_missing_project_dir_is_fail_closed_document(tmp_path):
+    home = tmp_path / "home"
+    missing = tmp_path / "no-such-project"
+    result = run_cli(
+        ["status", "--scope", "project", "--project-dir", str(missing), "--json"],
+        home=home,
+        check=False,
+    )
+    assert result.returncode == 1
+    payload = json.loads(result.stdout)
+    assert payload["schema"] == "claude-keysmith/v1"
+    assert payload["ok"] is False
+    assert payload["operation"] == "status"
+    assert "project directory" in payload["error"]
+
+
+def test_status_runtime_probe_failure_still_returns_json(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("CLAUDE_KEYSMITH_SHELL", "powershell")
+    monkeypatch.delenv("CLAUDE_KEYSMITH_SHELL_RC", raising=False)
+
+    def boom():
+        raise ValueError("runtime probe exploded")
+
+    monkeypatch.setattr(claude_instruct, "user_runtime_paths", boom)
+    status = claude_instruct.collect_status("user", None, "claude-project-rules", runtime=True)
+    assert status["schema"] == "claude-keysmith/v1"
+    assert status["runtime"]["runtime_ready"] is False
+    assert "runtime probe exploded" in status["runtime"]["error"]
+    assert status["runtime_readiness"]["runtime_ready"] is False
+    assert status["presence"]["memory_file"] is False
+
+
+def test_doctor_json_probe_failure_keeps_fixed_key_set(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("CLAUDE_KEYSMITH_SHELL", "powershell")
+    monkeypatch.delenv("CLAUDE_KEYSMITH_SHELL_RC", raising=False)
+
+    def boom():
+        raise ValueError("doctor probe exploded")
+
+    monkeypatch.setattr(claude_instruct, "user_runtime_paths", boom)
+    args = type("Args", (), {"json": True})()
+    captured = []
+    monkeypatch.setattr("builtins.print", lambda text: captured.append(text))
+    exit_status = claude_instruct.command_runtime_doctor(args)
+    assert exit_status == 1
+    payload = json.loads(captured[0])
+    assert set(payload) == {
+        "installation_type",
+        "upstream_candidates",
+        "upstream_path",
+        "system_prompt_file",
+        "append_prompt_file",
+        "settings_file",
+        "shell_kind",
+        "shell_rc",
+        "repair_actions",
+    }
+    assert "doctor probe exploded" in payload["repair_actions"][0]
+
+
 def test_version_reports_current_version(tmp_path):
     result = run_cli(["--version"], home=tmp_path / "home")
     assert result.stdout.strip() == f"claude-keysmith {claude_instruct.VERSION}"
@@ -850,15 +937,16 @@ def test_powershell_profile_accepts_user_module_path_before_directory_exists(
     )
 
 
-def test_powershell_profile_rejects_ambiguous_module_path_without_override(tmp_path, monkeypatch):
+def test_powershell_profile_falls_back_when_module_path_is_ambiguous(tmp_path, monkeypatch):
     home = tmp_path / "home"
     ambiguous = tmp_path / "Modules"
     ambiguous.mkdir()
     monkeypatch.delenv("CLAUDE_KEYSMITH_SHELL_RC", raising=False)
     monkeypatch.setenv("PSModulePath", str(ambiguous))
 
-    with pytest.raises(ValueError, match="CLAUDE_KEYSMITH_SHELL_RC"):
-        claude_instruct.powershell_profile_path(home)
+    assert claude_instruct.powershell_profile_path(home) == (
+        home / "Documents" / "WindowsPowerShell" / "Microsoft.PowerShell_profile.ps1"
+    )
 
 
 @pytest.mark.parametrize("profile_dir", ["PowerShell", "WindowsPowerShell"])
@@ -881,15 +969,50 @@ def test_powershell_profile_uses_redirected_user_documents_and_ignores_program_f
     )
 
 
-def test_powershell_profile_rejects_program_files_only_module_path(tmp_path, monkeypatch):
+def test_powershell_profile_falls_back_when_module_path_is_program_files_only(
+    tmp_path, monkeypatch
+):
     home = tmp_path / "home"
     program_files_modules = tmp_path / "Program Files" / "PowerShell" / "Modules"
     program_files_modules.mkdir(parents=True)
     monkeypatch.delenv("CLAUDE_KEYSMITH_SHELL_RC", raising=False)
     monkeypatch.setenv("PSModulePath", str(program_files_modules))
 
-    with pytest.raises(ValueError, match="CLAUDE_KEYSMITH_SHELL_RC"):
-        claude_instruct.powershell_profile_path(home)
+    assert claude_instruct.powershell_profile_path(home) == (
+        home / "Documents" / "WindowsPowerShell" / "Microsoft.PowerShell_profile.ps1"
+    )
+
+
+def test_powershell_profile_falls_back_when_psmodulepath_missing(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    monkeypatch.delenv("CLAUDE_KEYSMITH_SHELL_RC", raising=False)
+    monkeypatch.delenv("PSModulePath", raising=False)
+
+    assert claude_instruct.powershell_profile_path(home) == (
+        home / "Documents" / "WindowsPowerShell" / "Microsoft.PowerShell_profile.ps1"
+    )
+
+
+def test_powershell_profile_fallback_prefers_existing_ps7_profile(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    ps7 = home / "Documents" / "PowerShell" / "Microsoft.PowerShell_profile.ps1"
+    ps7.parent.mkdir(parents=True)
+    ps7.write_text("# existing\n", encoding="utf-8")
+    monkeypatch.delenv("CLAUDE_KEYSMITH_SHELL_RC", raising=False)
+    monkeypatch.delenv("PSModulePath", raising=False)
+
+    assert claude_instruct.powershell_profile_path(home) == ps7
+
+
+def test_powershell_profile_fallback_uses_chinese_documents_folder(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    profile = home / "文档" / "WindowsPowerShell" / "Microsoft.PowerShell_profile.ps1"
+    profile.parent.mkdir(parents=True)
+    profile.write_text("# existing\n", encoding="utf-8")
+    monkeypatch.delenv("CLAUDE_KEYSMITH_SHELL_RC", raising=False)
+    monkeypatch.delenv("PSModulePath", raising=False)
+
+    assert claude_instruct.powershell_profile_path(home) == profile
 
 
 def test_runtime_install_migrates_recognized_local_bin_launchers(tmp_path):

--- a/tests/test_claude_instruct.py
+++ b/tests/test_claude_instruct.py
@@ -1015,6 +1015,39 @@ def test_powershell_profile_fallback_uses_chinese_documents_folder(tmp_path, mon
     assert claude_instruct.powershell_profile_path(home) == profile
 
 
+def test_powershell_profile_isolated_home_ignores_machine_documents(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    machine = tmp_path / "machine-documents"
+    machine_profile = machine / "PowerShell" / "Microsoft.PowerShell_profile.ps1"
+    machine_profile.parent.mkdir(parents=True)
+    machine_profile.write_text("# machine\n", encoding="utf-8")
+    monkeypatch.delenv("CLAUDE_KEYSMITH_SHELL_RC", raising=False)
+    monkeypatch.delenv("PSModulePath", raising=False)
+    monkeypatch.setattr(claude_instruct, "_home_is_windows_user_profile", lambda _home: False)
+    monkeypatch.setattr(claude_instruct, "_windows_documents_from_known_folder", lambda: machine)
+    monkeypatch.setattr(claude_instruct, "_windows_documents_from_registry", lambda: machine)
+
+    assert claude_instruct.powershell_profile_path(home) == (
+        home / "Documents" / "WindowsPowerShell" / "Microsoft.PowerShell_profile.ps1"
+    )
+    assert claude_instruct.powershell_profile_path(home) != machine_profile
+
+
+def test_powershell_profile_real_user_home_uses_known_documents(tmp_path, monkeypatch):
+    home = tmp_path / "user"
+    redirected = tmp_path / "OneDrive" / "Documents"
+    profile = redirected / "PowerShell" / "Microsoft.PowerShell_profile.ps1"
+    profile.parent.mkdir(parents=True)
+    profile.write_text("# existing\n", encoding="utf-8")
+    monkeypatch.delenv("CLAUDE_KEYSMITH_SHELL_RC", raising=False)
+    monkeypatch.delenv("PSModulePath", raising=False)
+    monkeypatch.setattr(claude_instruct, "_home_is_windows_user_profile", lambda _home: True)
+    monkeypatch.setattr(claude_instruct, "_windows_documents_from_known_folder", lambda: redirected)
+    monkeypatch.setattr(claude_instruct, "_windows_documents_from_registry", lambda: None)
+
+    assert claude_instruct.powershell_profile_path(home) == profile
+
+
 def test_runtime_install_migrates_recognized_local_bin_launchers(tmp_path):
     home = tmp_path / "home"
     profile = home / "Documents" / "PowerShell" / "Microsoft.PowerShell_profile.ps1"


### PR DESCRIPTION
## 这两个 issue 可以合一个 PR

都是 Windows Desktop 打开后 runtime 探测失败，根因是同一条路径：`powershell_profile_path()` 只认用户级 `PSModulePath`。

Explorer / NSIS 启动的 sidecar **没有** PowerShell 引擎环境，`PSModulePath` 为空或只剩 Program Files / System32。于是：

- Dashboard `status --runtime --json` 往 stdout 打 `[错误]` 文本 → GUI 解析失败 → **状态加载失败**（#16）
- 部署向导若勾了 runtime，preview 直接 blocker：`无法从 PSModulePath 判断 PowerShell 5.1/7 profile`（#16 截图）
- Win10 上「连安装都不能安装」（#17 正文）走的是同一条 install preview

#17 附件是 Claude Code 的 `Service is busy`（HTTP **529** / 偶发 **500**）。那是 Anthropic 过载，不是 keysmith 把输出截断到 529/500 字节。本 PR 修的是安装/状态被 runtime 探测卡住；装上之后如果 Claude 仍 529，需要换时段或换模型，不是 CLI 输出上限。

## 改动

1. **Profile 解析**
   - 仍优先 `CLAUDE_KEYSMITH_SHELL_RC`，其次 `PSModulePath` 里第一个用户级 `WindowsPowerShell/Modules` 或 `PowerShell/Modules`
   - 没有用户级条目时：Documents Known Folder / 壳文件夹注册表 / `USERPROFILE\文档` → 已存在的 `Microsoft.PowerShell_profile.ps1`（先 5.1 后 7）→ 否则 Win10 默认 `Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1`
2. **`status --json` / `doctor --json`**
   - project-dir 不存在、runtime 探测失败都输出契约 JSON
   - GUI `parseStatusReport` 把 `ok: false` 当成带原文的 `ContractError`，不再显示「CLI 未输出稳定 JSON」

## 验证

- `python3 -m pytest tests/ -q` → **142 passed**
- `npx vitest run src/lib/parser.test.js` → **35 passed**
- 全量 GUI vitest 里 `buildInfo.guiVersion` 的 `0.1.0-beta.1` vs `0.1.0-beta.2` 是既有问题，与本 PR 无关

Fixes #16
Fixes #17